### PR TITLE
Implement S3 bucket and Snowflake architecture for raw PeMS data

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,6 +26,14 @@ jobs:
         # just use $SNOWFLAKE_PRIVATE_KEY
       - name: Set up private key
         run: echo "$PRIVATE_KEY" > $SNOWFLAKE_PRIVATE_KEY_PATH
+      - name: Setup terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: v1.4.0
+      - name: Install tflint
+        run: |
+          curl -s https://raw.githubusercontent.com/terraform-linters/\
+          tflint/master/install_linux.sh | bash
       - uses: actions/setup-python@v3
       - uses: snok/install-poetry@v1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,15 @@ repos:
     hooks:
       - id: yamllint
         args: []
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.77.1
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+        # Exclude modules to work around
+        # https://github.com/hashicorp/terraform/issues/28490
+        exclude: "terraform/[^/]+/modules/[^/]+/[^/]+$"
+      - id: terraform_tflint
   - repo: local
     hooks:
       - name: Dbt deps

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/terraform/environments/dev/.terraform.lock.hcl
+++ b/terraform/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.56.0"
+  constraints = "4.56.0"
+  hashes = [
+    "h1:CnpBvf3mH16Kcez47OsjmIeGkY2PUVihKRwbkyOvo48=",
+    "h1:koDunHl/LUmCAKy3VFie6MakXN7ng93v8HBRpKI8He8=",
+    "h1:v6DE95Ll2mxE96IGUsT/h6WQTU1d2cfHydWah1FgT20=",
+    "zh:1d2b7693a102da015a86b9235b554272b9280597011216c3ddd1a6dc95ad8dab",
+    "zh:28c3e8ebaa077f65c4ac5fd051c95887070293fcff0386dfc2e4b7e248a0aefa",
+    "zh:2a620bc4a87be06e7acac1bc15e966dba45df643bf6c3efb811e74e6c2122b03",
+    "zh:30d3ac148fa0634e7ba1de66e1af1328481c92cd774adcfc0e27f828103b17e0",
+    "zh:3d3eebf916f25e11b12dd3c692f8fe1e4c4e9a0c414af9d0d881ddebd28dcd39",
+    "zh:3f4600f2881c02fcc69080df68747c9a0b9b11cb002117fd918b7800f2ac402b",
+    "zh:7156fb12c3b4f2964f7e78cee97f31d95b43045467f90749d2ed545725c36baa",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a5bbc84fd37d468c7b016009776b6d2a287bbb746af81aba786cdf8eb5fce4a1",
+    "zh:d5322bcd4e11caddbbfaa1198893824d4b4d28f504517a3a87902cf86d75bd87",
+    "zh:d766eb9f86a40060d63e12ef674d7c9c47ec4e47ade487f1f49af8c89b441711",
+    "zh:df23f592b99f6617f09e449009bbb49068a69fc926b15ca29e30b068c9c67365",
+    "zh:e7b0acee2d98549731547259b539f598e18db07c0c202d3a34b922beff711054",
+    "zh:ec317f79fdcce934c39458ea312862e7f7ec48cafb8bcc9b5a00d9b78b629d81",
+    "zh:f78ec7a771867d96dfee96bf74523341ba42feeb64ce2f108b5bf2e7ebef0fef",
+  ]
+}

--- a/terraform/environments/dev/.terraform.lock.hcl
+++ b/terraform/environments/dev/.terraform.lock.hcl
@@ -25,3 +25,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f78ec7a771867d96dfee96bf74523341ba42feeb64ce2f108b5bf2e7ebef0fef",
   ]
 }
+
+provider "registry.terraform.io/snowflake-labs/snowflake" {
+  version     = "0.69.0"
+  constraints = "~> 0.61, 0.69.0"
+  hashes = [
+    "h1:0CSDES330nTqimmmNwQxxp24dDkRGYTrz46wjJDBG9M=",
+    "h1:S57eACfdn03/8yUFRcSA52BsBsuEIJ0KwP5jhdoKMuY=",
+    "h1:rB052GXnpNuUR9ZeGgiY8imkQqPWkI32PtiqWTORJXQ=",
+    "zh:05c38443ecce2a74568a182eb8a796db5d333846552d75c16b158f5034e824a3",
+    "zh:38b549a2e09b911709c85340222533cff9fde9c0de3e83cb906891822b340279",
+    "zh:3d4468d3be703c0545db94f6f1861ffd0f6e6e40cbdad6cf22506fcf368d33cd",
+    "zh:43ae1d8dd68545923ad460593b3f9c6d0a010b66c8ece7c62e4c2c716e3bb848",
+    "zh:4f4bb057e411138f876cc87b676269f23d62ffeafd4bbcf7d96521ee8abb2dff",
+    "zh:51c3f30ec1ede2c002d103e0dfeee187ef69be77c7a948355f6e5a5c505745f2",
+    "zh:74e7fd7d960a2e7e069941fb665e2873c4ced8cf84d5e1f8aded98ad9bb742c8",
+    "zh:97330c429ba7c17eec8ee325695bdc81093e1c70a275fd70ffeb00719ffc73ce",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/environments/dev/caltrans-pems-dev.tfbackend
+++ b/terraform/environments/dev/caltrans-pems-dev.tfbackend
@@ -1,0 +1,4 @@
+bucket = "dse-infra-dev-terraform-state"
+dynamodb_table = "dse-infra-dev-terraform-state-lock"
+key = "caltrans-pems-dev.tfstate"
+region = "us-west-1"

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,0 +1,47 @@
+##################################
+#        Terraform Setup         #
+##################################
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.56.0"
+    }
+  }
+
+  backend "s3" {
+  }
+}
+
+locals {
+  owner       = "caltrans"
+  environment = "dev"
+  project     = "pems"
+  region      = "us-west-2"
+}
+
+provider "aws" {
+  region = local.region
+
+  default_tags {
+    tags = {
+      Owner       = local.owner
+      Project     = local.project
+      Environment = local.environment
+    }
+  }
+}
+
+############################
+#      Infrastructure      #
+############################
+
+module "s3_lake" {
+  source = "../../modules/s3-lake"
+
+  prefix = "${local.owner}-${local.project}-${local.environment}"
+  region = local.region
+}

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "4.56.0"
     }
+    snowflake = {
+      source  = "Snowflake-Labs/snowflake"
+      version = "0.69"
+    }
   }
 
   backend "s3" {
@@ -21,6 +25,7 @@ locals {
   environment = "dev"
   project     = "pems"
   region      = "us-west-2"
+  locator     = "NGB13288"
 }
 
 provider "aws" {
@@ -35,13 +40,61 @@ provider "aws" {
   }
 }
 
+# This provider is intentionally low-permission. In Snowflake, object creators are
+# the default owners of the object. To control the owner, we create different provider
+# blocks with different roles, and require that all snowflake resources explicitly
+# flag the role they want for the creator.
+provider "snowflake" {
+  account = local.locator
+  role    = "PUBLIC"
+}
+
+# Snowflake provider for creating databases, warehouses, etc.
+provider "snowflake" {
+  alias   = "sysadmin"
+  account = local.locator
+  role    = "SYSADMIN"
+}
+
+# Snowflake provider for managing grants to roles.
+provider "snowflake" {
+  alias   = "securityadmin"
+  account = local.locator
+  role    = "SECURITYADMIN"
+}
+
+# Snowflake provider for managing user accounts and roles.
+provider "snowflake" {
+  alias   = "useradmin"
+  account = local.locator
+  role    = "USERADMIN"
+}
+
 ############################
-#      Infrastructure      #
+#    AWS Infrastructure    #
 ############################
 
 module "s3_lake" {
   source = "../../modules/s3-lake"
+  providers = {
+    aws = aws
+  }
 
   prefix = "${local.owner}-${local.project}-${local.environment}"
   region = local.region
+}
+
+############################
+# Snowflake Infrastructure #
+############################
+
+module "elt" {
+  source = "github.com/cagov/data-infrastructure.git//terraform/snowflake/modules/elt?ref=74a522f"
+  providers = {
+    snowflake.securityadmin = snowflake.securityadmin,
+    snowflake.sysadmin      = snowflake.sysadmin,
+    snowflake.useradmin     = snowflake.useradmin,
+  }
+
+  environment = upper(local.environment)
 }

--- a/terraform/modules/s3-lake/iam.tf
+++ b/terraform/modules/s3-lake/iam.tf
@@ -1,0 +1,16 @@
+##################################
+#        IAM Service Users       #
+##################################
+
+# NOTE: in general, policies and roles are defined close to the resources
+# they support.
+
+# Airflow service user for writing to S3
+resource "aws_iam_user" "airflow_s3_writer" {
+  name = "${var.prefix}-airflow-s3-writer"
+}
+
+resource "aws_iam_user_policy_attachment" "airflow_s3_writer_policy_attachment" {
+  user       = aws_iam_user.airflow_s3_writer.name
+  policy_arn = aws_iam_policy.pems_raw_write.arn
+}

--- a/terraform/modules/s3-lake/main.tf
+++ b/terraform/modules/s3-lake/main.tf
@@ -1,0 +1,18 @@
+##################################
+#        Terraform Setup         #
+##################################
+
+terraform {
+  # Note: when a package is added or updated, we have to update the lockfile in a
+  # platform-independent way, cf. https://github.com/hashicorp/terraform/issues/28041
+  # To update the lockfile run:
+  #
+  # terraform providers lock -platform=linux_amd64 -platform=darwin_amd64
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.56.0"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/terraform/modules/s3-lake/s3.tf
+++ b/terraform/modules/s3-lake/s3.tf
@@ -4,7 +4,7 @@
 
 # PeMS raw
 resource "aws_s3_bucket" "pems_raw" {
-  bucket = "${var.prefix}-${var.region}-pems-raw"
+  bucket = "${var.prefix}-${var.region}-raw"
 }
 
 # Versioning
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "pems_raw_write" {
 }
 
 resource "aws_iam_policy" "pems_raw_write" {
-  name        = "${var.prefix}-${var.region}-pems-raw-write"
+  name        = "${var.prefix}-${var.region}-raw-write"
   description = "Policy allowing write for s3 pems raw bucket"
   policy      = data.aws_iam_policy_document.pems_raw_write.json
 }

--- a/terraform/modules/s3-lake/s3.tf
+++ b/terraform/modules/s3-lake/s3.tf
@@ -1,0 +1,72 @@
+##################################
+#  Caltrans PeMS Infrastructure  #
+##################################
+
+# PeMS raw
+resource "aws_s3_bucket" "pems_raw" {
+  bucket = "${var.prefix}-${var.region}-pems-raw"
+}
+
+# Versioning
+resource "aws_s3_bucket_versioning" "pems_raw" {
+  bucket = aws_s3_bucket.pems_raw.bucket
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# Write access
+data "aws_iam_policy_document" "pems_raw_write" {
+  statement {
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [aws_s3_bucket.pems_raw.arn]
+  }
+  statement {
+    actions = [
+      "s3:PutObject",
+    ]
+    resources = ["${aws_s3_bucket.pems_raw.arn}/*"]
+  }
+}
+
+resource "aws_iam_policy" "pems_raw_write" {
+  name        = "${var.prefix}-${var.region}-pems-raw-write"
+  description = "Policy allowing write for s3 pems raw bucket"
+  policy      = data.aws_iam_policy_document.pems_raw_write.json
+}
+
+
+# Public read access
+data "aws_iam_policy_document" "pems_raw_read" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      aws_s3_bucket.pems_raw.arn,
+      "${aws_s3_bucket.pems_raw.arn}/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "pems_raw_read" {
+  bucket = aws_s3_bucket.pems_raw.id
+  policy = data.aws_iam_policy_document.pems_raw_read.json
+}
+
+resource "aws_s3_bucket_public_access_block" "pems_raw" {
+  bucket = aws_s3_bucket.pems_raw.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}

--- a/terraform/modules/s3-lake/variables.tf
+++ b/terraform/modules/s3-lake/variables.tf
@@ -1,0 +1,10 @@
+variable "prefix" {
+  description = "Prefix for resource names"
+  type        = string
+}
+
+variable "region" {
+  description = "Region for AWS resources"
+  type        = string
+  default     = "us-west-2"
+}


### PR DESCRIPTION
Fixes #7, fixes #8

This creates a publicly-readable bucket (I can change that for development if folks feel nervous about that), as well as a service account with write access to that bucket. I've also created our reference Snowflake architecture here.