### PR TITLE
Adding terraform updates for sentinel service user - CALTRANS

### DIFF
--- a/terraform/environments/dev/.terraform.lock.hcl
+++ b/terraform/environments/dev/.terraform.lock.hcl
@@ -5,8 +5,6 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.56.0"
   constraints = "4.56.0"
   hashes = [
-    "h1:CnpBvf3mH16Kcez47OsjmIeGkY2PUVihKRwbkyOvo48=",
-    "h1:koDunHl/LUmCAKy3VFie6MakXN7ng93v8HBRpKI8He8=",
     "h1:v6DE95Ll2mxE96IGUsT/h6WQTU1d2cfHydWah1FgT20=",
     "zh:1d2b7693a102da015a86b9235b554272b9280597011216c3ddd1a6dc95ad8dab",
     "zh:28c3e8ebaa077f65c4ac5fd051c95887070293fcff0386dfc2e4b7e248a0aefa",
@@ -28,11 +26,9 @@ provider "registry.terraform.io/hashicorp/aws" {
 
 provider "registry.terraform.io/snowflake-labs/snowflake" {
   version     = "0.71.0"
-  constraints = "~> 0.61, 0.71.0"
+  constraints = "~> 0.61, 0.71.0, ~> 0.71"
   hashes = [
-    "h1:OzG5BB2GnRFN5Z9UlprM1QKabM0BchFxCNbAGFZK7ug=",
     "h1:gGn8oiljlcX7AvdPpoFzQGVZ5NPJ51NycPJUQxF3US4=",
-    "h1:lr1cAHKmrg6pe4J/5EbjTpkP9C2BEfneEILC7007xn4=",
     "zh:16d905e911a699693cea3b8d95b7dfbecbb74779cb78fbf98532fd910350cc3b",
     "zh:2d099d606a315f699100b9259078a87905f1760c69a4002c210c0d40401110a4",
     "zh:317115adad369ff94bacc2f64be8276c6c4bb99d254855f038d8881fb49036f8",

--- a/terraform/environments/dev/.terraform.lock.hcl
+++ b/terraform/environments/dev/.terraform.lock.hcl
@@ -5,6 +5,8 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.56.0"
   constraints = "4.56.0"
   hashes = [
+    "h1:CnpBvf3mH16Kcez47OsjmIeGkY2PUVihKRwbkyOvo48=",
+    "h1:koDunHl/LUmCAKy3VFie6MakXN7ng93v8HBRpKI8He8=",
     "h1:v6DE95Ll2mxE96IGUsT/h6WQTU1d2cfHydWah1FgT20=",
     "zh:1d2b7693a102da015a86b9235b554272b9280597011216c3ddd1a6dc95ad8dab",
     "zh:28c3e8ebaa077f65c4ac5fd051c95887070293fcff0386dfc2e4b7e248a0aefa",
@@ -28,7 +30,9 @@ provider "registry.terraform.io/snowflake-labs/snowflake" {
   version     = "0.71.0"
   constraints = "~> 0.61, 0.71.0, ~> 0.71"
   hashes = [
+    "h1:OzG5BB2GnRFN5Z9UlprM1QKabM0BchFxCNbAGFZK7ug=",
     "h1:gGn8oiljlcX7AvdPpoFzQGVZ5NPJ51NycPJUQxF3US4=",
+    "h1:lr1cAHKmrg6pe4J/5EbjTpkP9C2BEfneEILC7007xn4=",
     "zh:16d905e911a699693cea3b8d95b7dfbecbb74779cb78fbf98532fd910350cc3b",
     "zh:2d099d606a315f699100b9259078a87905f1760c69a4002c210c0d40401110a4",
     "zh:317115adad369ff94bacc2f64be8276c6c4bb99d254855f038d8881fb49036f8",

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -116,8 +116,9 @@ resource "aws_iam_role_policy_attachment" "mwaa_execution_role" {
 
 # Main ELT architecture
 module "elt" {
-  source = "github.com/cagov/data-infrastructure.git//terraform/snowflake/modules/elt?ref=74a522f"
+  source = "github.com/cagov/data-infrastructure.git//terraform/snowflake/modules/elt?ref=5fe13b2"
   providers = {
+    snowflake.accountadmin = snowflake.accountadmin,
     snowflake.securityadmin = snowflake.securityadmin,
     snowflake.sysadmin      = snowflake.sysadmin,
     snowflake.useradmin     = snowflake.useradmin,

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -118,7 +118,7 @@ resource "aws_iam_role_policy_attachment" "mwaa_execution_role" {
 module "elt" {
   source = "github.com/cagov/data-infrastructure.git//terraform/snowflake/modules/elt?ref=5fe13b2"
   providers = {
-    snowflake.accountadmin = snowflake.accountadmin,
+    snowflake.accountadmin  = snowflake.accountadmin,
     snowflake.securityadmin = snowflake.securityadmin,
     snowflake.sysadmin      = snowflake.sysadmin,
     snowflake.useradmin     = snowflake.useradmin,

--- a/terraform/environments/prd/.terraform.lock.hcl
+++ b/terraform/environments/prd/.terraform.lock.hcl
@@ -5,8 +5,6 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.56.0"
   constraints = "4.56.0"
   hashes = [
-    "h1:CnpBvf3mH16Kcez47OsjmIeGkY2PUVihKRwbkyOvo48=",
-    "h1:koDunHl/LUmCAKy3VFie6MakXN7ng93v8HBRpKI8He8=",
     "h1:v6DE95Ll2mxE96IGUsT/h6WQTU1d2cfHydWah1FgT20=",
     "zh:1d2b7693a102da015a86b9235b554272b9280597011216c3ddd1a6dc95ad8dab",
     "zh:28c3e8ebaa077f65c4ac5fd051c95887070293fcff0386dfc2e4b7e248a0aefa",
@@ -30,9 +28,7 @@ provider "registry.terraform.io/snowflake-labs/snowflake" {
   version     = "0.71.0"
   constraints = "~> 0.61, 0.71.0, ~> 0.71"
   hashes = [
-    "h1:OzG5BB2GnRFN5Z9UlprM1QKabM0BchFxCNbAGFZK7ug=",
     "h1:gGn8oiljlcX7AvdPpoFzQGVZ5NPJ51NycPJUQxF3US4=",
-    "h1:lr1cAHKmrg6pe4J/5EbjTpkP9C2BEfneEILC7007xn4=",
     "zh:16d905e911a699693cea3b8d95b7dfbecbb74779cb78fbf98532fd910350cc3b",
     "zh:2d099d606a315f699100b9259078a87905f1760c69a4002c210c0d40401110a4",
     "zh:317115adad369ff94bacc2f64be8276c6c4bb99d254855f038d8881fb49036f8",

--- a/terraform/environments/prd/.terraform.lock.hcl
+++ b/terraform/environments/prd/.terraform.lock.hcl
@@ -5,6 +5,8 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.56.0"
   constraints = "4.56.0"
   hashes = [
+    "h1:CnpBvf3mH16Kcez47OsjmIeGkY2PUVihKRwbkyOvo48=",
+    "h1:koDunHl/LUmCAKy3VFie6MakXN7ng93v8HBRpKI8He8=",
     "h1:v6DE95Ll2mxE96IGUsT/h6WQTU1d2cfHydWah1FgT20=",
     "zh:1d2b7693a102da015a86b9235b554272b9280597011216c3ddd1a6dc95ad8dab",
     "zh:28c3e8ebaa077f65c4ac5fd051c95887070293fcff0386dfc2e4b7e248a0aefa",
@@ -28,7 +30,9 @@ provider "registry.terraform.io/snowflake-labs/snowflake" {
   version     = "0.71.0"
   constraints = "~> 0.61, 0.71.0, ~> 0.71"
   hashes = [
+    "h1:OzG5BB2GnRFN5Z9UlprM1QKabM0BchFxCNbAGFZK7ug=",
     "h1:gGn8oiljlcX7AvdPpoFzQGVZ5NPJ51NycPJUQxF3US4=",
+    "h1:lr1cAHKmrg6pe4J/5EbjTpkP9C2BEfneEILC7007xn4=",
     "zh:16d905e911a699693cea3b8d95b7dfbecbb74779cb78fbf98532fd910350cc3b",
     "zh:2d099d606a315f699100b9259078a87905f1760c69a4002c210c0d40401110a4",
     "zh:317115adad369ff94bacc2f64be8276c6c4bb99d254855f038d8881fb49036f8",

--- a/terraform/environments/prd/main.tf
+++ b/terraform/environments/prd/main.tf
@@ -116,8 +116,9 @@ resource "aws_iam_role_policy_attachment" "mwaa_execution_role" {
 
 # Main ELT architecture
 module "elt" {
-  source = "github.com/cagov/data-infrastructure.git//terraform/snowflake/modules/elt?ref=74a522f"
+  source = "github.com/cagov/data-infrastructure.git//terraform/snowflake/modules/elt?ref=5fe13b2"
   providers = {
+    snowflake.accountadmin = snowflake.accountadmin,
     snowflake.securityadmin = snowflake.securityadmin,
     snowflake.sysadmin      = snowflake.sysadmin,
     snowflake.useradmin     = snowflake.useradmin,

--- a/terraform/environments/prd/main.tf
+++ b/terraform/environments/prd/main.tf
@@ -118,7 +118,7 @@ resource "aws_iam_role_policy_attachment" "mwaa_execution_role" {
 module "elt" {
   source = "github.com/cagov/data-infrastructure.git//terraform/snowflake/modules/elt?ref=5fe13b2"
   providers = {
-    snowflake.accountadmin = snowflake.accountadmin,
+    snowflake.accountadmin  = snowflake.accountadmin,
     snowflake.securityadmin = snowflake.securityadmin,
     snowflake.sysadmin      = snowflake.sysadmin,
     snowflake.useradmin     = snowflake.useradmin,


### PR DESCRIPTION
Updated Terraform config, using the latest data-infrastructure updates, to add Sentinel service user accounts to Snowflake.