### PR TITLE
disabled trailing whitespaces 

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -8,3 +8,4 @@ rules:
     required: false
   truthy:
     allowed-values: ["true", "false"]
+trailing-spaces: disable


### PR DESCRIPTION
(From Ian: This rule has slightly different semantics from the prettier yaml formatter. Disable in favor of the latter.)