### PR TITLE
code to select samples that are between 1 and 1224, which constitutes as too few samples for a given lane

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -8,4 +8,5 @@ rules:
     required: false
   truthy:
     allowed-values: ["true", "false"]
-trailing-spaces: disable
+  trailing-spaces: disable
+  new-lines: disable

--- a/transform/models/intermediate/int_pems__too_few_samples_test.sql
+++ b/transform/models/intermediate/int_pems__too_few_samples_test.sql
@@ -1,0 +1,85 @@
+-- # of samples < 60% of the max collected samples during the test period.
+-- max value is a static value, which should be two samples per minute times 60 mins/hr times 17 hours in a day 
+-- (1224 is the static number of samples) - 
+-- this max value doesnt need to be calculated at the station_id level bc it's the same
+-- btwn 1 and 1224 is too few samples.
+
+with
+diagnostic_samples_per_station as (
+    select * from {{ ref("int_pems__diagnostic_samples_per_station") }}
+),
+
+lane1_too_few_samples as (
+    select lane1_sample_cnt
+
+    from diagnostic_samples_per_station
+    where lane1_sample_cnt between 1 and (0.6 * (2 * 60 * 17))
+),
+
+lane2_too_few_samples as (
+    select lane2_sample_cnt
+
+    from diagnostic_samples_per_station
+    where lane2_sample_cnt between 1 and (0.6 * (2 * 60 * 17))
+),
+
+lane3_too_few_samples as (
+    select lane3_sample_cnt
+
+    from diagnostic_samples_per_station
+    where lane3_sample_cnt between 1 and (0.6 * (2 * 60 * 17))
+),
+
+lane4_too_few_samples as (
+    select lane4_sample_cnt
+
+    from diagnostic_samples_per_station
+    where lane4_sample_cnt between 1 and (0.6 * (2 * 60 * 17))
+),
+
+lane5_too_few_samples as (
+    select lane5_sample_cnt
+
+    from diagnostic_samples_per_station
+    where lane5_sample_cnt between 1 and (0.6 * (2 * 60 * 17))
+),
+
+lane6_too_few_samples as (
+    select lane6_sample_cnt
+
+    from diagnostic_samples_per_station
+    where lane6_sample_cnt between 1 and (0.6 * (2 * 60 * 17))
+)
+
+-- , lane7_too_few_samples as (
+--     select lane7_sample_cnt
+
+--     from diagnostic_samples_per_station
+--     where lane7_sample_cnt between 1 and (0.6 * (2 * 60 * 17))
+-- )
+
+-- , lane8_too_few_samples as (
+-- select LANE8_SAMPLE_CNT
+
+-- from diagnostic_samples_per_station
+-- where LANE8_SAMPLE_CNT between 1 and (0.6*(2*60*17))
+-- )
+
+select
+    lane1_too_few_samples.*,
+    lane2_too_few_samples.*,
+    lane3_too_few_samples.*,
+    lane4_too_few_samples.*,
+    lane5_too_few_samples.*,
+    lane6_too_few_samples.*
+-- , lane7_too_few_samples.* 
+-- , lane8_too_few_samples.*  -- currently lane 7 and lane 8 causes the query to produce no results!
+
+from lane1_too_few_samples,
+    lane2_too_few_samples,
+    lane3_too_few_samples,
+    lane4_too_few_samples,
+    lane5_too_few_samples,
+    lane6_too_few_samples
+-- , lane7_too_few_samples 
+-- , lane8_too_few_samples -- currently lane 7 and lane 8 causes the query to produce no results!

--- a/transform/models/intermediate/int_pems__too_few_samples_test.sql
+++ b/transform/models/intermediate/int_pems__too_few_samples_test.sql
@@ -17,6 +17,9 @@ diagnostic_samples_per_station as (
 select
     sample_date,
     station_id,
+    -- # of samples < 60% of the max collected samples during the test period
+    -- max value: 2 samples per minute times 60 mins/hr times 17 hours in a day which == 1224
+    -- btwn 1 and 1224 is too few samples
     coalesce(lane1_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane1_too_few_samples,
     coalesce(lane2_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane2_too_few_samples,
     coalesce(lane3_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane3_too_few_samples,
@@ -25,10 +28,6 @@ select
     coalesce(lane6_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane6_too_few_samples,
     coalesce(lane7_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane7_too_few_samples,
     coalesce(lane8_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane8_too_few_samples
-
-    -- # of samples < 60% of the max collected samples during the test period
-    -- max value: 2 samples per minute times 60 mins/hr times 17 hours in a day which == 1224 
-    -- btwn 1 and 1224 is too few samples
 
 from diagnostic_samples_per_station
 group by all

--- a/transform/models/intermediate/int_pems__too_few_samples_test.sql
+++ b/transform/models/intermediate/int_pems__too_few_samples_test.sql
@@ -1,12 +1,17 @@
--- # of samples < 60% of the max collected samples during the test period.
--- max value is a static value, which should be two samples per minute times 60 mins/hr times 17 hours in a day 
--- (1224 is the static number of samples) - 
--- this max value doesnt need to be calculated at the station_id level bc it's the same
--- btwn 1 and 1224 is too few samples.
+{{ config(
+        materialized='incremental',
+        unique_key=['station_id', 'sample_date']
+    )
+}}
 
 with
 diagnostic_samples_per_station as (
     select * from {{ ref("int_pems__diagnostic_samples_per_station") }}
+    {% if is_incremental() %}
+        where sample_date > (
+            select dateadd(day, -2, max(sample_date)) from {{ this }}
+        )
+    {% endif %}
 )
 
 select
@@ -20,6 +25,10 @@ select
     coalesce(lane6_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane6_too_few_samples,
     coalesce(lane7_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane7_too_few_samples,
     coalesce(lane8_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane8_too_few_samples
+
+    -- # of samples < 60% of the max collected samples during the test period
+    -- max value: 2 samples per minute times 60 mins/hr times 17 hours in a day which == 1224 
+    -- btwn 1 and 1224 is too few samples
 
 from diagnostic_samples_per_station
 group by all

--- a/transform/models/intermediate/int_pems__too_few_samples_test.sql
+++ b/transform/models/intermediate/int_pems__too_few_samples_test.sql
@@ -7,79 +7,19 @@
 with
 diagnostic_samples_per_station as (
     select * from {{ ref("int_pems__diagnostic_samples_per_station") }}
-),
-
-lane1_too_few_samples as (
-    select lane1_sample_cnt
-
-    from diagnostic_samples_per_station
-    where lane1_sample_cnt between 1 and (0.6 * (2 * 60 * 17))
-),
-
-lane2_too_few_samples as (
-    select lane2_sample_cnt
-
-    from diagnostic_samples_per_station
-    where lane2_sample_cnt between 1 and (0.6 * (2 * 60 * 17))
-),
-
-lane3_too_few_samples as (
-    select lane3_sample_cnt
-
-    from diagnostic_samples_per_station
-    where lane3_sample_cnt between 1 and (0.6 * (2 * 60 * 17))
-),
-
-lane4_too_few_samples as (
-    select lane4_sample_cnt
-
-    from diagnostic_samples_per_station
-    where lane4_sample_cnt between 1 and (0.6 * (2 * 60 * 17))
-),
-
-lane5_too_few_samples as (
-    select lane5_sample_cnt
-
-    from diagnostic_samples_per_station
-    where lane5_sample_cnt between 1 and (0.6 * (2 * 60 * 17))
-),
-
-lane6_too_few_samples as (
-    select lane6_sample_cnt
-
-    from diagnostic_samples_per_station
-    where lane6_sample_cnt between 1 and (0.6 * (2 * 60 * 17))
 )
 
--- , lane7_too_few_samples as (
---     select lane7_sample_cnt
-
---     from diagnostic_samples_per_station
---     where lane7_sample_cnt between 1 and (0.6 * (2 * 60 * 17))
--- )
-
--- , lane8_too_few_samples as (
--- select LANE8_SAMPLE_CNT
-
--- from diagnostic_samples_per_station
--- where LANE8_SAMPLE_CNT between 1 and (0.6*(2*60*17))
--- )
-
 select
-    lane1_too_few_samples.*,
-    lane2_too_few_samples.*,
-    lane3_too_few_samples.*,
-    lane4_too_few_samples.*,
-    lane5_too_few_samples.*,
-    lane6_too_few_samples.*
--- , lane7_too_few_samples.* 
--- , lane8_too_few_samples.*  -- currently lane 7 and lane 8 causes the query to produce no results!
+    sample_date,
+    station_id,
+    coalesce(lane1_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane1_too_few_samples,
+    coalesce(lane2_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane2_too_few_samples,
+    coalesce(lane3_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane3_too_few_samples,
+    coalesce(lane4_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane4_too_few_samples,
+    coalesce(lane5_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane5_too_few_samples,
+    coalesce(lane6_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane6_too_few_samples,
+    coalesce(lane7_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane7_too_few_samples,
+    coalesce(lane8_sample_cnt between 1 and (0.6 * (2 * 60 * 17)), false) as lane8_too_few_samples
 
-from lane1_too_few_samples,
-    lane2_too_few_samples,
-    lane3_too_few_samples,
-    lane4_too_few_samples,
-    lane5_too_few_samples,
-    lane6_too_few_samples
--- , lane7_too_few_samples 
--- , lane8_too_few_samples -- currently lane 7 and lane 8 causes the query to produce no results!
+from diagnostic_samples_per_station
+group by all


### PR DESCRIPTION
This is still in progress. I need to:

- [x] Figure out how to include lane 7 and 8 even if no sample meet the criteria. Currently those two lane pass the check, but the way the query is constructed it causes the check to not be run against the other lanes.
- [x] Materialize this as incremental

Closes #79 