### PR TITLE
5-minute aggregated VDS data

### DIFF
--- a/transform/macros/_macros.yml
+++ b/transform/macros/_macros.yml
@@ -1,0 +1,12 @@
+version: 2
+
+macros:
+  - name: get_snowflake_refresh_warehouse()
+    description: |
+      Full refreshes of incremental models sometimes need a little bit of
+      extra firepower. This returns an appropriate (i.e. 4XL) warehouse
+      for that case. Use it with caution! This returns large if either of
+      the following conditions are met:
+
+      * The target table doesn't exist (i.e., hasn't been built yet)
+      * the `--full-refresh` flag is set via the CLI.

--- a/transform/macros/_macros.yml
+++ b/transform/macros/_macros.yml
@@ -1,7 +1,7 @@
 version: 2
 
 macros:
-  - name: get_snowflake_refresh_warehouse()
+  - name: get_snowflake_refresh_warehouse
     description: |
       Full refreshes of incremental models sometimes need a little bit of
       extra firepower. This returns an appropriate (i.e. 4XL) warehouse

--- a/transform/macros/get_snowflake_refresh_warehouse.sql
+++ b/transform/macros/get_snowflake_refresh_warehouse.sql
@@ -1,0 +1,16 @@
+{% macro get_snowflake_refresh_warehouse() %}
+  {% set relation = adapter.get_relation(this.database, this.schema, this.table) %}
+  {% if target.name == 'prd' %}
+    {% set suffix = 'PRD' %}
+  {% else %}
+    {% set suffix = 'DEV' %}
+  {% endif %}
+  {% if flags.FULL_REFRESH or relation is none %}
+    {% set size = '4XL' %}
+  {% else %}
+    {% set size = 'XS' %}
+  {% endif %}
+  {% set warehouse = 'TRANSFORMING_' ~ size ~ '_' ~ suffix %}
+  {{ return(warehouse) }}
+{% endmacro %}
+

--- a/transform/models/intermediate/vds/_vds.yml
+++ b/transform/models/intermediate/vds/_vds.yml
@@ -199,19 +199,3 @@ models:
         description: The average of the occupancy values over the sample period.
       - name: OCCUPANCY_8
         description: The average of the occupancy values over the sample period.
-      - name: SPEED_1
-        description: The average of the speed values over the sample period.
-      - name: SPEED_2
-        description: The average of the speed values over the sample period.
-      - name: SPEED_3
-        description: The average of the speed values over the sample period.
-      - name: SPEED_4
-        description: The average of the speed values over the sample period.
-      - name: SPEED_5
-        description: The average of the speed values over the sample period.
-      - name: SPEED_6
-        description: The average of the speed values over the sample period.
-      - name: SPEED_7
-        description: The average of the speed values over the sample period.
-      - name: SPEED_8
-        description: The average of the speed values over the sample period.

--- a/transform/models/intermediate/vds/_vds.yml
+++ b/transform/models/intermediate/vds/_vds.yml
@@ -155,3 +155,63 @@ models:
           The lane number for the detector. This seems to be reported as
           1, 10, 100, 1000, 10000, etc for each successive lane, rather than counting up
           from one.
+
+  - name: int_vds__five_minute_station_agg
+    description: |
+      Raw 30 second sample data aggregated to the 5 minute level.
+      Flow/volume numbers are summed, occupancy and speed numbers are averaged.
+    columns:
+      - name: ID
+        description: The station ID
+      - name: SAMPLE_DATE
+        description: The date on which the sample was taken
+      - name: SAMPLE_TIMESTAMP
+        description: The timestamp of the start for the 5 minute aggregated samples.
+      - name: FLOW_1
+        description: The sum of the flow values over the sample period.
+      - name: FLOW_2
+        description: The sum of the flow values over the sample period.
+      - name: FLOW_3
+        description: The sum of the flow values over the sample period.
+      - name: FLOW_4
+        description: The sum of the flow values over the sample period.
+      - name: FLOW_5
+        description: The sum of the flow values over the sample period.
+      - name: FLOW_6
+        description: The sum of the flow values over the sample period.
+      - name: FLOW_7
+        description: The sum of the flow values over the sample period.
+      - name: FLOW_8
+        description: The sum of the flow values over the sample period.
+      - name: OCCUPANCY_1
+        description: The average of the occupancy values over the sample period.
+      - name: OCCUPANCY_2
+        description: The average of the occupancy values over the sample period.
+      - name: OCCUPANCY_3
+        description: The average of the occupancy values over the sample period.
+      - name: OCCUPANCY_4
+        description: The average of the occupancy values over the sample period.
+      - name: OCCUPANCY_5
+        description: The average of the occupancy values over the sample period.
+      - name: OCCUPANCY_1
+        description: The average of the occupancy values over the sample period.
+      - name: OCCUPANCY_7
+        description: The average of the occupancy values over the sample period.
+      - name: OCCUPANCY_8
+        description: The average of the occupancy values over the sample period.
+      - name: SPEED_1
+        description: The average of the speed values over the sample period.
+      - name: SPEED_2
+        description: The average of the speed values over the sample period.
+      - name: SPEED_3
+        description: The average of the speed values over the sample period.
+      - name: SPEED_4
+        description: The average of the speed values over the sample period.
+      - name: SPEED_5
+        description: The average of the speed values over the sample period.
+      - name: SPEED_6
+        description: The average of the speed values over the sample period.
+      - name: SPEED_7
+        description: The average of the speed values over the sample period.
+      - name: SPEED_8
+        description: The average of the speed values over the sample period.

--- a/transform/models/intermediate/vds/int_vds__five_minute_station_agg.sql
+++ b/transform/models/intermediate/vds/int_vds__five_minute_station_agg.sql
@@ -50,16 +50,7 @@ aggregated as (
         avg(occupancy_5) as occupancy_5,
         avg(occupancy_6) as occupancy_6,
         avg(occupancy_7) as occupancy_7,
-        avg(occupancy_8) as occupancy_8,
-        -- Average of all the speed values
-        avg(speed_1) as speed_1,
-        avg(speed_2) as speed_2,
-        avg(speed_3) as speed_3,
-        avg(speed_4) as speed_4,
-        avg(speed_5) as speed_5,
-        avg(speed_6) as speed_6,
-        avg(speed_7) as speed_7,
-        avg(speed_8) as speed_8
+        avg(occupancy_8) as occupancy_8
     from station_raw
     group by id, sample_date, sample_timestamp_trunc
 )

--- a/transform/models/intermediate/vds/int_vds__five_minute_station_agg.sql
+++ b/transform/models/intermediate/vds/int_vds__five_minute_station_agg.sql
@@ -1,0 +1,66 @@
+{{ config(
+    materialized="incremental",
+    cluster_by=["sample_date"],
+    unique_key=["ID", "SAMPLE_TIMESTAMP"],
+) }}
+
+with station_raw as (
+    select
+        *,
+        /* Create a timestamp truncated down to the nearest five
+         minute bucket. This will be the the timestamp on which
+         we aggregate. If a 30-second interval straddles two different
+         buckets, it will be assigned to the one latter one due to
+         the floor() call.
+        */
+        dateadd(
+            'minute',
+            floor(minute(sample_timestamp) / 5) * 5,
+            trunc(sample_timestamp, 'hour')
+        ) as sample_timestamp_trunc
+    from {{ ref('stg_clearinghouse__station_raw') }}
+    {% if is_incremental() %}
+        -- Look back two days to account for any late-arriving data
+        where sample_date > (
+            select dateadd(day, -1, max(sample_date)) from {{ this }}
+        )
+    {% endif %}
+),
+
+aggregated as (
+    select
+        id,
+        sample_date,
+        sample_timestamp_trunc as sample_timestamp,
+        -- Sum of all the flow values
+        sum(flow_1) as flow_1,
+        sum(flow_2) as flow_2,
+        sum(flow_3) as flow_3,
+        sum(flow_4) as flow_4,
+        sum(flow_5) as flow_5,
+        sum(flow_6) as flow_6,
+        sum(flow_7) as flow_7,
+        sum(flow_8) as flow_8,
+        -- Average of all the occupancy values
+        avg(occupancy_1) as occupancy_1,
+        avg(occupancy_2) as occupancy_2,
+        avg(occupancy_3) as occupancy_3,
+        avg(occupancy_4) as occupancy_4,
+        avg(occupancy_5) as occupancy_5,
+        avg(occupancy_6) as occupancy_6,
+        avg(occupancy_7) as occupancy_7,
+        avg(occupancy_8) as occupancy_8,
+        -- Average of all the speed values
+        avg(speed_1) as speed_1,
+        avg(speed_2) as speed_2,
+        avg(speed_3) as speed_3,
+        avg(speed_4) as speed_4,
+        avg(speed_5) as speed_5,
+        avg(speed_6) as speed_6,
+        avg(speed_7) as speed_7,
+        avg(speed_8) as speed_8
+    from station_raw
+    group by id, sample_date, sample_timestamp_trunc
+)
+
+select * from aggregated

--- a/transform/models/intermediate/vds/int_vds__five_minute_station_agg.sql
+++ b/transform/models/intermediate/vds/int_vds__five_minute_station_agg.sql
@@ -23,7 +23,7 @@ with station_raw as (
     {% if is_incremental() %}
         -- Look back two days to account for any late-arriving data
         where sample_date > (
-            select dateadd(day, -1, max(sample_date)) from {{ this }}
+            select dateadd(day, -2, max(sample_date)) from {{ this }}
         )
     {% endif %}
 ),

--- a/transform/models/intermediate/vds/int_vds__five_minute_station_agg.sql
+++ b/transform/models/intermediate/vds/int_vds__five_minute_station_agg.sql
@@ -2,6 +2,7 @@
     materialized="incremental",
     cluster_by=["sample_date"],
     unique_key=["ID", "SAMPLE_TIMESTAMP"],
+    snowflake_warehouse=get_snowflake_refresh_warehouse()
 ) }}
 
 with station_raw as (


### PR DESCRIPTION
This creates incremental model aggregating 30 second VDS data to five minutes. There is no attempt to do any imputation, just rolling up the sample data to a larger time bucket

Fixes #117 

cc @AzamBeg-Caltrans