### PR TITLE
Don't do "relation is none" check

### DIFF
--- a/transform/macros/get_snowflake_refresh_warehouse.sql
+++ b/transform/macros/get_snowflake_refresh_warehouse.sql
@@ -5,7 +5,7 @@
   {% else %}
     {% set suffix = 'DEV' %}
   {% endif %}
-  {% if flags.FULL_REFRESH or relation is none %}
+  {% if flags.FULL_REFRESH %}
     {% set size = '4XL' %}
   {% else %}
     {% set size = 'XS' %}


### PR DESCRIPTION
 The "relation is none" check in our `get_snowflake_refresh_warehouse() appears to not work during the compile phase.

See #129 for more info. Fixes #129 