### PR TITLE
Sync all columns on schema changes

### DIFF
--- a/transform/dbt_project.yml
+++ b/transform/dbt_project.yml
@@ -35,6 +35,7 @@ vars:
   pems_clearinghouse_start_date: "'2023-01-01'"
 
 models:
+  +on_schema_change: "sync_all_columns" so less manual… 
   caldata_mdsa_caltrans_pems:
     staging:
       +materialized: view

--- a/transform/dbt_project.yml
+++ b/transform/dbt_project.yml
@@ -35,7 +35,7 @@ vars:
   pems_clearinghouse_start_date: "'2023-01-01'"
 
 models:
-  +on_schema_change: "sync_all_columns" so less manual… 
+  +on_schema_change: "sync_all_columns"
   caldata_mdsa_caltrans_pems:
     staging:
       +materialized: view


### PR DESCRIPTION
added this flag: +on_schema_change: "sync_all_columns" so less manual full refreshes have to be kicked off. see dbt docs: https://docs.getdbt.com/docs/build/incremental-models#how-do-i-rebuild-an-incremental-model