### PR TITLE
Regional regression

### DIFF
--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__nearby_stations.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__nearby_stations.sql
@@ -63,7 +63,7 @@ nearest_upstream_station_pairs as (
     from station_pairs
     where
         delta_postmile < 0
-        and delta_postmile > -5.0
+        and delta_postmile >= -5.0
         and id != other_id
 ),
 
@@ -90,9 +90,7 @@ nearest_station_pairs as (
 nearest_station_pairs_with_tag as (
     select
         *,
-        case
-            when row_number <= 1 then 1 else 0
-        end as local_reg
+        row_number = 1 as other_station_is_local
     from nearest_station_pairs
 )
 

--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__nearby_stations.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__nearby_stations.sql
@@ -39,7 +39,7 @@ nearest_downstream_station_pairs as (
         _valid_from,
         _valid_to,
         row_number() over (partition by id, _valid_from order by abs(delta_postmile) asc)
-            as row_number
+            as distance_ranking
     from station_pairs
     where
         delta_postmile > 0
@@ -59,7 +59,7 @@ nearest_upstream_station_pairs as (
         _valid_from,
         _valid_to,
         row_number() over (partition by id, _valid_from order by abs(delta_postmile) asc)
-            as row_number
+            as distance_ranking
     from station_pairs
     where
         delta_postmile < 0
@@ -70,17 +70,20 @@ nearest_upstream_station_pairs as (
 self_pairs as (
     select
         *,
-        0 as row_number
+        0 as distance_ranking
     from station_pairs
     where id = other_id
 ),
 
 nearest_station_pairs as (
-    select * from self_pairs
+    select *
+    from self_pairs
     union all
-    select * from nearest_downstream_station_pairs
+    select *
+    from nearest_downstream_station_pairs
     union all
-    select * from nearest_upstream_station_pairs
+    select *
+    from nearest_upstream_station_pairs
     order by district asc, freeway asc, id asc
 ),
 
@@ -88,7 +91,7 @@ nearest_station_pairs as (
 nearest_station_pairs_with_tag as (
     select
         *,
-        row_number = 1 as other_station_is_local
+        distance_ranking <= 1 as other_station_is_local
     from nearest_station_pairs
 )
 

--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__nearby_stations.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__nearby_stations.sql
@@ -76,6 +76,15 @@ nearest_station_pairs as (
     union all
     select * from nearest_upstream_station_pairs
     order by district asc, freeway asc, id asc
+),
+
+-- assign the tag that is qulified for local and regional regression
+nearest_station_pairs_with_tag as (
+    select
+        *,
+        coalesce (delta_postmile <= 1.0, false) as local_counters,
+        coalesce (delta_postmile <= 5.0, false) as regional_counters
+    from nearest_station_pairs
 )
 
-select * from nearest_station_pairs
+select * from nearest_station_pairs_with_tag

--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__nearby_stations.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__nearby_stations.sql
@@ -76,13 +76,43 @@ self_pairs as (
 ),
 
 nearest_station_pairs as (
-    select *
+    select
+        id,
+        other_id,
+        district,
+        freeway,
+        direction,
+        type,
+        delta_postmile,
+        _valid_from,
+        _valid_to,
+        distance_ranking
     from self_pairs
     union all
-    select *
+    select
+        id,
+        other_id,
+        district,
+        freeway,
+        direction,
+        type,
+        delta_postmile,
+        _valid_from,
+        _valid_to,
+        distance_ranking
     from nearest_downstream_station_pairs
     union all
-    select *
+    select
+        id,
+        other_id,
+        district,
+        freeway,
+        direction,
+        type,
+        delta_postmile,
+        _valid_from,
+        _valid_to,
+        distance_ranking
     from nearest_upstream_station_pairs
     order by district asc, freeway asc, id asc
 ),

--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__nearby_stations.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__nearby_stations.sql
@@ -17,7 +17,9 @@ station_pairs as (
         a._valid_to
     from station_meta as a
     inner join station_meta as b
-        on a.freeway = b.freeway and a.direction = b.direction and a.type = b.type and a.meta_date = b.meta_date
+        on
+            a.freeway = b.freeway and a.direction = b.direction and a.type = b.type
+            and a.meta_date = b.meta_date
     -- Most performance metrics are restricted to mainline and HV lanes.
     -- Furthermore, when looking at upstream and downstream stations, it
     -- does not make sense to include, e.g., ramps. So for the time being
@@ -36,7 +38,8 @@ nearest_downstream_station_pairs as (
         delta_postmile,
         _valid_from,
         _valid_to,
-        row_number() over (partition by id, _valid_from order by abs(delta_postmile) asc) as row_number
+        row_number() over (partition by id, _valid_from order by abs(delta_postmile) asc)
+            as row_number
     from station_pairs
     where
         delta_postmile > 0
@@ -55,7 +58,8 @@ nearest_upstream_station_pairs as (
         delta_postmile,
         _valid_from,
         _valid_to,
-        row_number() over (partition by id, _valid_from order by abs(delta_postmile) asc) as row_number
+        row_number() over (partition by id, _valid_from order by abs(delta_postmile) asc)
+            as row_number
     from station_pairs
     where
         delta_postmile < 0

--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__nearby_stations.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__nearby_stations.sql
@@ -76,11 +76,9 @@ self_pairs as (
 ),
 
 nearest_station_pairs as (
-    select *
-    from self_pairs
+    select * from self_pairs
     union all
-    select *
-    from nearest_downstream_station_pairs
+    select * from nearest_downstream_station_pairs
     union all
     select * from nearest_upstream_station_pairs
     order by district asc, freeway asc, id asc

--- a/transform/models/intermediate/imputation/_imputation.yml
+++ b/transform/models/intermediate/imputation/_imputation.yml
@@ -1,7 +1,7 @@
 version: 2
 
 models:
-  - name: int_imputation__local_regression_coefficients
+  - name: int_imputation__local_regional_regression_coefficients
     description: |
       Linear regression slopes and intercepts for pairs of detectors.
       They are evaluated at regular dates (`regression_date`) in order to
@@ -36,6 +36,14 @@ models:
         description: The slope of the occupancy regression
       - name: occupancy_intercept
         description: The intercept of the occupancy regression
+      - name: OTHER_STATION_IS_LOCAL
+        description: tagging wheather the other id is local counters
+          or regional counters. If the other id is just upstream or downstream
+          then it is considered as local counters. On the other hand
+          except local counters if any counters are located within 5 miles
+          upstream and downstream, then it is considered as regional id.
+          This boolean function where True means local counters and false means
+          regional counters.
   - name: int_imputation__five_minute_aggregation
     description: |
       dfdf

--- a/transform/models/intermediate/imputation/_imputation.yml
+++ b/transform/models/intermediate/imputation/_imputation.yml
@@ -37,7 +37,8 @@ models:
       - name: occupancy_intercept
         description: The intercept of the occupancy regression
       - name: OTHER_STATION_IS_LOCAL
-        description: tagging wheather the other id is local counters
+        description: |
+          tagging wheather the other id is local counters
           or regional counters. If the other id is just upstream or downstream
           then it is considered as local counters. On the other hand
           except local counters if any counters are located within 5 miles

--- a/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation.sql
+++ b/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation.sql
@@ -92,7 +92,7 @@ samples_not_requiring_imputation as (
 
 -- read the model coefficients
 coeffs as (
-    select * from {{ ref('int_imputation__local_regression_coefficients') }}
+    select * from {{ ref('int_imputation__local_regional_regression_coefficients') }}
 ),
 
 -- join the coeeficent with missing volume,occupancy and speed dataframe

--- a/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation.sql
+++ b/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation.sql
@@ -34,6 +34,13 @@ with base as (
     {% endif %}
 ),
 
+/* Get all detectors that are "real" in that they represent lanes that exist
+   (rather than lane 8 in a two lane road) with a status of "Good" */
+good_detectors as (
+    select * from {{ ref('int_diagnostics__real_detector_status') }}
+    where status = 'Good'
+),
+
 /* Join with the "good detectors"
 model to flag whether we consider a detector to be operating
 correctly for a given day.
@@ -50,16 +57,15 @@ unimputed as (
         -- If the station_id in the join is not null, it means that the detector
         -- is considered to be "good" for a given date. TODO: likely restructure
         -- once the real_detectors model is eliminated.
-        (detectors.station_id is not null) as detector_is_good,
+        (good_detectors.station_id is not null) as detector_is_good,
         coalesce(base.speed_weighted, (base.volume_sum * 22) / nullifzero(base.occupancy_avg) * (1 / 5280) * 12)
             as speed_five_mins
     from base
-    left join {{ ref('int_diagnostics__real_detector_status') }} as detectors
+    left join good_detectors
         on
-            base.id = detectors.station_id
-            and base.lane = detectors.lane
-            and base.sample_date = detectors.sample_date
--- where detectors.status = 'Good'/this code will return empty 'samples_requiring_imputation'
+            base.id = good_detectors.station_id
+            and base.lane = good_detectors.lane
+            and base.sample_date = good_detectors.sample_date
 ),
 
 -- get the data that require imputation
@@ -113,7 +119,7 @@ samples_requiring_imputation_with_coeffs as (
     asof join coeffs  -- noqa
         match_condition(samples_requiring_imputation.sample_date >= coeffs.regression_date)  -- noqa
         on samples_requiring_imputation.id = coeffs.id
-    where other_station_is_local = true
+    where coeffs.other_station_is_local = true
 ),
 
 -- Read the neighbours that have volume, occupancy and speed data.

--- a/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation.sql
+++ b/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation.sql
@@ -59,7 +59,7 @@ unimputed as (
             base.id = detectors.station_id
             and base.lane = detectors.lane
             and base.sample_date = detectors.sample_date
-    where detectors.status = 'Good'
+-- where detectors.status = 'Good'/this code will return empty 'samples_requiring_imputation'
 ),
 
 -- get the data that require imputation
@@ -113,6 +113,7 @@ samples_requiring_imputation_with_coeffs as (
     asof join coeffs  -- noqa
         match_condition(samples_requiring_imputation.sample_date >= coeffs.regression_date)  -- noqa
         on samples_requiring_imputation.id = coeffs.id
+    where other_station_is_local = true
 ),
 
 -- Read the neighbours that have volume, occupancy and speed data.

--- a/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation_regional_reg.sql
+++ b/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation_regional_reg.sql
@@ -59,7 +59,7 @@ unimputed as (
             base.id = detectors.station_id
             and base.lane = detectors.lane
             and base.sample_date = detectors.sample_date
-    -- where detectors.status = 'Good'
+-- where detectors.status = 'Good'
 ),
 
 -- get the data that require imputation
@@ -108,7 +108,7 @@ samples_requiring_imputation_with_coeffs as (
         coeffs.occupancy_slope,
         coeffs.occupancy_intercept,
         coeffs.regression_date,
-        coeffs.local_reg
+        coeffs.other_station_is_local
     from samples_requiring_imputation
     -- TODO: update sqlfluff to support asof joins
     asof join coeffs  -- noqa
@@ -140,7 +140,7 @@ imputed as (
         lane,
         sample_date,
         sample_timestamp,
-        local_reg,
+        other_station_is_local,
         -- Volume calculation
         greatest(median(volume_slope * volume_sum_nbr + volume_intercept), 0) as volume,
         -- Occupancy calculation
@@ -150,7 +150,7 @@ imputed as (
         any_value(regression_date) as regression_date
     from
         samples_requiring_imputation_with_neighbors
-    group by id, lane, sample_date, sample_timestamp, local_reg
+    group by id, lane, sample_date, sample_timestamp, other_station_is_local
 ),
 
 -- combine imputed and non-imputed dataframe together
@@ -161,7 +161,7 @@ agg_with_regional_imputation as (
         imputed.occupancy as imp_occupancy,
         imputed.speed as imp_speed,
         imputed.regression_date,
-        imputed.local_reg
+        imputed.other_station_is_local
     from unimputed
     left join imputed
         on

--- a/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation_regional_reg.sql
+++ b/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation_regional_reg.sql
@@ -59,7 +59,7 @@ unimputed as (
             base.id = detectors.station_id
             and base.lane = detectors.lane
             and base.sample_date = detectors.sample_date
--- where detectors.status = 'Good'
+    -- where detectors.status = 'Good'
 ),
 
 -- get the data that require imputation

--- a/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation_regional_reg.sql
+++ b/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation_regional_reg.sql
@@ -1,0 +1,172 @@
+{{ config(
+        materialized='incremental',
+        cluster_by=["sample_date"],
+        unique_key=["id", "lane", "sample_timestamp"],
+        snowflake_warehouse = get_snowflake_refresh_warehouse(small="XL"),
+    )
+}}
+
+-- Select unimputed data
+with base as (
+    select * from {{ ref('int_clearinghouse__five_minute_station_agg') }}
+    {% if is_incremental() %}
+    -- Look back two days to account for any late-arriving data
+        where
+            sample_date > (
+                select
+                    dateadd(
+                        day,
+                        {{ var("incremental_model_look_back") }},
+                        max(sample_date)
+                    )
+                from {{ this }}
+            )
+            {% if target.name != 'prd' %}
+                and sample_date
+                >= dateadd(
+                    day,
+                    5 * {{ var("dev_model_look_back") }},
+                    current_date()
+                )
+            {% endif %}
+    {% elif target.name != 'prd' %}
+        where sample_date >= dateadd(day, 5 * {{ var("dev_model_look_back") }}, current_date())
+    {% endif %}
+),
+
+/* Join with the "good detectors"
+model to flag whether we consider a detector to be operating
+correctly for a given day.
+*/
+unimputed as (
+    select
+        base.id,
+        base.lane,
+        base.sample_date,
+        base.sample_timestamp,
+        base.volume_sum,
+        base.occupancy_avg,
+        base.speed_weighted,
+        -- If the station_id in the join is not null, it means that the detector
+        -- is considered to be "good" for a given date. TODO: likely restructure
+        -- once the real_detectors model is eliminated.
+        (detectors.station_id is not null) as detector_is_good,
+        coalesce(base.speed_weighted, (base.volume_sum * 22) / nullifzero(base.occupancy_avg) * (1 / 5280) * 12)
+            as speed_five_mins
+    from base
+    left join {{ ref('int_diagnostics__real_detector_status') }} as detectors
+        on
+            base.id = detectors.station_id
+            and base.lane = detectors.lane
+            and base.sample_date = detectors.sample_date
+    where detectors.status = 'Good'
+),
+
+-- get the data that require imputation
+samples_requiring_imputation as (
+    select
+        id,
+        lane,
+        sample_date,
+        sample_timestamp,
+        volume_sum,
+        occupancy_avg,
+        speed_five_mins
+    from unimputed
+    where not detector_is_good
+),
+
+-- get the data that does not require imputation
+samples_not_requiring_imputation as (
+    select
+        id,
+        lane,
+        sample_date,
+        sample_timestamp,
+        volume_sum,
+        occupancy_avg,
+        speed_five_mins
+    from unimputed
+    where detector_is_good
+),
+
+-- read the model coefficients
+coeffs as (
+    select * from {{ ref('int_imputation__local_regional_regression_coefficients') }}
+),
+
+-- join the coeeficent with missing volume,occupancy and speed dataframe
+samples_requiring_imputation_with_coeffs as (
+    select
+        samples_requiring_imputation.*,
+        coeffs.rr_other_id,
+        coeffs.rr_other_lane,
+        coeffs.rr_speed_slope,
+        coeffs.rr_speed_intercept,
+        coeffs.rr_volume_slope,
+        coeffs.rr_volume_intercept,
+        coeffs.rr_occupancy_slope,
+        coeffs.rr_occupancy_intercept,
+        coeffs.regression_date
+    from samples_requiring_imputation
+    -- TODO: update sqlfluff to support asof joins
+    asof join coeffs  -- noqa
+        match_condition(samples_requiring_imputation.sample_date >= coeffs.regression_date)  -- noqa
+        on samples_requiring_imputation.id = coeffs.id
+),
+
+-- Read the neighbours that have volume, occupancy and speed data.
+-- We only join with neighbors that don't require imputation, as
+-- there is no point to imputing bad data from bad data.
+samples_requiring_imputation_with_neighbors as (
+    select
+        imp.*,
+        non_imp.speed_five_mins as speed_five_mins_nbr,
+        non_imp.volume_sum as volume_sum_nbr,
+        non_imp.occupancy_avg as occupancy_avg_nbr
+    from samples_requiring_imputation_with_coeffs as imp
+    inner join samples_not_requiring_imputation as non_imp
+        on
+            imp.rr_other_id = non_imp.id
+            and imp.sample_date = non_imp.sample_date
+            and imp.sample_timestamp = non_imp.sample_timestamp
+),
+
+-- apply imputation models to impute volume, occupancy and speed
+imputed as (
+    select
+        id,
+        lane,
+        sample_date,
+        sample_timestamp,
+        -- Volume calculation
+        greatest(median(rr_volume_slope * volume_sum_nbr + rr_volume_intercept), 0) as volume,
+        -- Occupancy calculation
+        least(greatest(median(rr_occupancy_slope * occupancy_avg_nbr + rr_occupancy_intercept), 0), 1) as occupancy,
+        -- Speed calculation
+        greatest(median(rr_speed_slope * speed_five_mins_nbr + rr_speed_intercept), 0) as speed,
+        any_value(regression_date) as regression_date
+    from
+        samples_requiring_imputation_with_neighbors
+    group by id, lane, sample_date, sample_timestamp
+)
+
+-- combine imputed and non-imputed dataframe together
+-- agg_with_regional_imputation as (
+--     select
+--         unimputed.*,
+--         imputed.volume as volume_regional_regression,
+--         imputed.occupancy as occupancy_regional_regression,
+--         imputed.speed as speed_regional_regression,
+--         imputed.regression_date
+--     from unimputed
+--     left join imputed
+--         on
+--             unimputed.id = imputed.id
+--             and unimputed.lane = imputed.lane
+--             and unimputed.sample_date = imputed.sample_date
+--             and unimputed.sample_timestamp = imputed.sample_timestamp
+-- )
+
+-- select the final CTE
+select * from agg_with_regional_imputation

--- a/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation_regional_reg.sql
+++ b/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation_regional_reg.sql
@@ -158,7 +158,7 @@ agg_with_regional_imputation as (
     select
         unimputed.*,
         imputed.volume as imp_volume,
-        imputed.occupancy as impu_occupancy,
+        imputed.occupancy as imp_occupancy,
         imputed.speed as imp_speed,
         imputed.regression_date,
         imputed.local_reg

--- a/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation_regional_reg.sql
+++ b/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation_regional_reg.sql
@@ -169,4 +169,4 @@ imputed as (
 -- )
 
 -- select the final CTE
-select * from agg_with_regional_imputation
+select * from samples_requiring_imputation

--- a/transform/models/intermediate/imputation/int_imputation__local_regional_regression_coefficients.sql
+++ b/transform/models/intermediate/imputation/int_imputation__local_regional_regression_coefficients.sql
@@ -28,7 +28,8 @@ with regression_dates as (
 nearby_stations as (
     select
         nearby.id,
-        nearby.other_id
+        nearby.other_id,
+        nearby.local_counters
     from {{ ref('int_clearinghouse__nearby_stations') }} as nearby
     inner join regression_dates
         on
@@ -36,8 +37,7 @@ nearby_stations as (
             and regression_dates.regression_date < coalesce(nearby._valid_to, current_date)
     -- only choose stations where they are actually reasonably close to each other,
     -- arbitrarily choose 1 mile
-    where
-        abs(nearby.delta_postmile) <= 1
+    where nearby.regional_counters = TRUE
 ),
 
 -- Get all of the detectors that are producing good data, based on
@@ -106,7 +106,8 @@ detector_counts_pairwise as (
         a.volume_sum as volume,
         b.volume_sum as other_volume,
         a.occupancy_avg as occupancy,
-        b.occupancy_avg as other_occupancy
+        b.occupancy_avg as other_occupancy,
+        nearby_stations.local_counters
     from detector_counts as a
     left join nearby_stations on a.id = nearby_stations.id
     inner join detector_counts as b
@@ -116,9 +117,8 @@ detector_counts_pairwise as (
             and a.sample_timestamp = b.sample_timestamp
 ),
 
--- Aggregate the self-joined table to get the slope
--- and intercept of the regression.
-detector_counts_regression as (
+-- develop regional regression model
+detector_counts_regional_regression as (
     select
         id,
         other_id,
@@ -127,16 +127,16 @@ detector_counts_regression as (
         district,
         regression_date,
         -- speed regression model
-        regr_slope(speed, other_speed) as speed_slope,
-        regr_intercept(speed, other_speed) as speed_intercept,
+        regr_slope(speed, other_speed) as rr_speed_slope,
+        regr_intercept(speed, other_speed) as rr_speed_intercept,
         -- flow or volume regression model
-        regr_slope(volume, other_volume) as volume_slope,
-        regr_intercept(volume, other_volume) as volume_intercept,
+        regr_slope(volume, other_volume) as rr_volume_slope,
+        regr_intercept(volume, other_volume) as rr_volume_intercept,
         -- occupancy regression model
-        regr_slope(occupancy, other_occupancy) as occupancy_slope,
-        regr_intercept(occupancy, other_occupancy) as occupancy_intercept
+        regr_slope(occupancy, other_occupancy) as rr_occupancy_slope,
+        regr_intercept(occupancy, other_occupancy) as rr_occupancy_intercept
     from detector_counts_pairwise
-    where not (id = other_id and lane = other_lane) -- don't bother regressing on self!
+    where not (id = other_id and lane = other_lane)-- don't bother regressing on self!
     group by id, other_id, lane, other_lane, district, regression_date
     -- No point in regressing if the variables are all null,
     -- this can save significant time.
@@ -144,6 +144,67 @@ detector_counts_regression as (
         (count(volume) > 0 and count(other_volume) > 0)
         or (count(occupancy) > 0 and count(other_occupancy) > 0)
         or (count(speed) > 0 and count(other_speed) > 0)
+),
+
+-- Aggregate the self-joined table to get the slope
+-- and intercept of the regression.
+detector_counts_local_regression as (
+    select
+        id,
+        other_id,
+        lane,
+        other_lane,
+        district,
+        regression_date,
+        -- speed regression model
+        regr_slope(speed, other_speed) as lr_speed_slope,
+        regr_intercept(speed, other_speed) as lr_speed_intercept,
+        -- flow or volume regression model
+        regr_slope(volume, other_volume) as lr_volume_slope,
+        regr_intercept(volume, other_volume) as lr_volume_intercept,
+        -- occupancy regression model
+        regr_slope(occupancy, other_occupancy) as lr_occupancy_slope,
+        regr_intercept(occupancy, other_occupancy) as lr_occupancy_intercept
+    from detector_counts_pairwise
+    where not (id = other_id and lane = other_lane) and local_counters = TRUE -- don't bother regressing on self!
+    group by id, other_id, lane, other_lane, district, regression_date
+    -- No point in regressing if the variables are all null,
+    -- this can save significant time.
+    having
+        (count(volume) > 0 and count(other_volume) > 0)
+        or (count(occupancy) > 0 and count(other_occupancy) > 0)
+        or (count(speed) > 0 and count(other_speed) > 0)
+),
+
+-- now join local and regional regression coefficient togetehr
+detector_counts_regression as (
+    select
+        rrc.id,
+        rrc.other_id as rr_other_id,
+        rrc.lane,
+        rrc.other_lane as rr_other_lane,
+        rrc.regression_date,
+        rrc.district,
+        rrc.rr_occupancy_intercept,
+        rrc.rr_occupancy_slope,
+        rrc.rr_speed_intercept,
+        rrc.rr_speed_slope,
+        rrc.rr_volume_intercept,
+        rrc.rr_volume_slope,
+        lrc.other_lane as lr_other_lane,
+        lrc.other_id as lr_other_id,
+        lrc.lr_occupancy_intercept,
+        lrc.lr_occupancy_slope,
+        lrc.lr_speed_intercept,
+        lrc.lr_speed_slope,
+        lrc.lr_volume_intercept,
+        lrc.lr_volume_slope
+    from detector_counts_regional_regression as rrc
+    inner join detector_counts_local_regression as lrc
+        on
+            rrc.id = lrc.id
+            and rrc.lane = lrc.lane
+            and rrc.regression_date = lrc.regression_date
 )
 
 select * from detector_counts_regression


### PR DESCRIPTION
This PR updated the codes to deploy regional and local regression together. The regional regression consider 5 miles upstream and downstream ring buffer along the ML and HOV while local regression considered just upstream and downstream stations.  The regression type is tracked by boolean (local reg=true, regional regression=false). This PR is similar to local regression!