### PR TITLE
Fix identification of stations needing imputation

### DIFF
--- a/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation.sql
+++ b/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation.sql
@@ -2,7 +2,7 @@
         materialized='incremental',
         cluster_by=["sample_date"],
         unique_key=["id", "lane", "sample_timestamp"],
-        snowflake_warehouse = get_snowflake_refresh_warehouse(big="XL", small="XL"),
+        snowflake_warehouse = get_snowflake_refresh_warehouse(big="XL", small="XS"),
     )
 }}
 

--- a/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation.sql
+++ b/transform/models/intermediate/imputation/int_imputation__five_minute_aggregation.sql
@@ -2,7 +2,7 @@
         materialized='incremental',
         cluster_by=["sample_date"],
         unique_key=["id", "lane", "sample_timestamp"],
-        snowflake_warehouse = get_snowflake_refresh_warehouse(big="XL", small="XS"),
+        snowflake_warehouse = get_snowflake_refresh_warehouse(big="XL", small="XL"),
     )
 }}
 
@@ -34,6 +34,13 @@ with base as (
     {% endif %}
 ),
 
+/* Get all detectors that are "real" in that they represent lanes that exist
+   (rather than lane 8 in a two lane road) with a status of "Good" */
+good_detectors as (
+    select * from {{ ref('int_diagnostics__real_detector_status') }}
+    where status = 'Good'
+),
+
 /* Join with the "good detectors"
 model to flag whether we consider a detector to be operating
 correctly for a given day.
@@ -50,16 +57,15 @@ unimputed as (
         -- If the station_id in the join is not null, it means that the detector
         -- is considered to be "good" for a given date. TODO: likely restructure
         -- once the real_detectors model is eliminated.
-        (detectors.station_id is not null) as detector_is_good,
+        (good_detectors.station_id is not null) as detector_is_good,
         coalesce(base.speed_weighted, (base.volume_sum * 22) / nullifzero(base.occupancy_avg) * (1 / 5280) * 12)
             as speed_five_mins
     from base
-    left join {{ ref('int_diagnostics__real_detector_status') }} as detectors
+    left join good_detectors
         on
-            base.id = detectors.station_id
-            and base.lane = detectors.lane
-            and base.sample_date = detectors.sample_date
-    where detectors.status = 'Good'
+            base.id = good_detectors.station_id
+            and base.lane = good_detectors.lane
+            and base.sample_date = good_detectors.sample_date
 ),
 
 -- get the data that require imputation


### PR DESCRIPTION
This fixes an issue with the initial selection of the five-minute data where I made a mistake in clause ordering, causing the samples requiring imputation to be filtered too early, so that no samples were actually being imputed (whoops!).

Thanks @mmmiah for the discussion here, I think this will fix the issue for both #209 and #234.