### PR TITLE
Consolidation of local and regional regression

### DIFF
--- a/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes_local_regional.sql
+++ b/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes_local_regional.sql
@@ -1,0 +1,2 @@
+{{ config(materialized='table') }}
+

--- a/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes_local_regional.sql
+++ b/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes_local_regional.sql
@@ -1,2 +1,19 @@
 {{ config(materialized='table') }}
 
+--join regional regression with local regression
+with local_regional_para as (
+    select
+        lrp.*,
+        rrp.imp_occupancy as occupancy_regional_regression,
+        rrp.imp_volume as volume_regional_regression,
+        rrp.imp_speed as speed_regional_regression
+    from {{ ref('int_imputation__detector_agg_five_minutes') }} as lrp
+    left join {{ ref('int_imputation__detector_agg_five_minutes_regional_reg') }} as rrp
+        on
+            lrp.id = rrp.id
+            and lrp.lane = rrp.lane
+            and lrp.sample_timestamp = rrp.sample_timestamp
+            and lrp.regression_date = rrp.regression_date
+)
+
+select * from local_regional_para

--- a/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes_local_regional.sql
+++ b/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes_local_regional.sql
@@ -1,19 +1,56 @@
-{{ config(materialized='table') }}
+{{ config(
+    materialized="incremental",
+    cluster_by=["sample_date"],
+    unique_key=["id", "lane","sample_date", "sample_timestamp",'regression_date'],
+    snowflake_warehouse = get_snowflake_refresh_warehouse(small="XL")
+) }}
+
+-- read local region estimates
+with local_reg as (
+    select
+        id,
+        lane,
+        speed_local_regression,
+        occupancy_local_regression,
+        volume_local_regression,
+        detector_is_good,
+        regression_date,
+        sample_date,
+        sample_timestamp
+    from {{ ref('int_imputation__detector_agg_five_minutes') }}
+    where {{ make_model_incremental('sample_date') }}
+),
+
+-- read regional regression estimates
+regional_reg as (
+    select
+        id,
+        lane,
+        detector_is_good,
+        regression_date,
+        sample_date,
+        sample_timestamp,
+        imp_occupancy as occupancy_regional_regression,
+        imp_volume as volume_regional_regression,
+        imp_speed as speed_regional_regression
+    from {{ ref('int_imputation__detector_agg_five_minutes_regional_reg') }}
+    where {{ make_model_incremental('sample_date') }}
+),
 
 --join regional regression with local regression
-with local_regional_para as (
+local_regional_estimates as (
     select
-        lrp.*,
-        rrp.imp_occupancy as occupancy_regional_regression,
-        rrp.imp_volume as volume_regional_regression,
-        rrp.imp_speed as speed_regional_regression
-    from {{ ref('int_imputation__detector_agg_five_minutes') }} as lrp
-    left join {{ ref('int_imputation__detector_agg_five_minutes_regional_reg') }} as rrp
+        local_reg.*,
+        regional_reg.occupancy_regional_regression,
+        regional_reg.volume_regional_regression,
+        regional_reg.speed_regional_regression
+    from local_reg
+    left join regional_reg
         on
-            lrp.id = rrp.id
-            and lrp.lane = rrp.lane
-            and lrp.sample_timestamp = rrp.sample_timestamp
-            and lrp.regression_date = rrp.regression_date
+            local_reg.id = regional_reg.id
+            and local_reg.lane = regional_reg.lane
+            and local_reg.sample_timestamp = regional_reg.sample_timestamp
+            and local_reg.regression_date = regional_reg.regression_date
 )
 
-select * from local_regional_para
+select * from local_regional_estimates

--- a/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes_local_regional.sql
+++ b/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes_local_regional.sql
@@ -10,13 +10,13 @@ with local_reg as (
     select
         id,
         lane,
-        speed_local_regression,
-        occupancy_local_regression,
-        volume_local_regression,
-        detector_is_good,
         regression_date,
         sample_date,
-        sample_timestamp
+        sample_timestamp,
+        detector_is_good,
+        speed_local_regression,
+        occupancy_local_regression,
+        volume_local_regression
     from {{ ref('int_imputation__detector_agg_five_minutes') }}
     where {{ make_model_incremental('sample_date') }}
 ),
@@ -26,10 +26,10 @@ regional_reg as (
     select
         id,
         lane,
-        detector_is_good,
         regression_date,
         sample_date,
         sample_timestamp,
+        detector_is_good,
         imp_occupancy as occupancy_regional_regression,
         imp_volume as volume_regional_regression,
         imp_speed as speed_regional_regression


### PR DESCRIPTION
This PR consolidate the local and regional regression estimates together based on issue #240. The join is done in a incremental form to avoid large joining over historical time period. 