### PR TITLE
Include Normalized Flow in Detector 5-min agg Model

### DIFF
--- a/transform/models/intermediate/clearinghouse/_clearinghouse.yml
+++ b/transform/models/intermediate/clearinghouse/_clearinghouse.yml
@@ -107,6 +107,12 @@ models:
           Lane associated with a route and station from raw data.
       - name: volume_sum
         description: Number of vehicle that passed over the detector during the sample period for the lane.
+      - name: volume_normalized
+        description: |
+          For the 5-minute aggregation there should be 10 30-second samples collected. If 10 or more
+          samples are collected the aggregated (sum) volume rounded to the nearest integer value is used
+          but if less than 10 samples are recieved in the 5-minute timeframe the flow is normalized using
+          the equation: 10 / sample count * sum(volume)
       - name: zero_vol_ct
         description: Counts the number of raw data samples where a lane's volume (flow) value equals 0.
       - name: occupancy_avg

--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes.sql
@@ -83,6 +83,11 @@ agg as (
             sample_ct_{{ lane }} as sample_ct,
             {{ lane }} as lane,
             volume_{{ lane }} as volume_sum,
+            round(iff(
+                sample_ct_{{ lane }} >= 10, volume_{{ lane }},
+                10 / nullifzero(sample_ct_{{ lane }}) * volume_{{ lane }}
+            ))
+                as volume_normalized,
             zero_vol_ct_{{ lane }} as zero_vol_ct,
             occupancy_{{ lane }} as occupancy_avg,
             zero_occ_ct_{{ lane }} as zero_occ_ct,


### PR DESCRIPTION
Create a `volume_normalized` field in the `int_clearinghouse__detector_agg_five_minutes.sql` model that returns a volume value based on the number of 30-second samples received and update the associated yml. For example, if a detector has a volume of 40 vehicles in 5 minutes but only 5 out of 10 samples are received (5 samples are not reported by the device), the normalized value is 10 samples / 5 samples recieved  * 40 vehicles = 80 vehicles