### PR TITLE
Update big refresh warehouse to XL

### DIFF
--- a/transform/macros/get_snowflake_refresh_warehouse.sql
+++ b/transform/macros/get_snowflake_refresh_warehouse.sql
@@ -1,4 +1,4 @@
-{% macro get_snowflake_refresh_warehouse(big="4XL", small="XS") %}
+{% macro get_snowflake_refresh_warehouse(big="XL", small="XS") %}
   {% if target.name == 'prd' %}
     {% set suffix = 'PRD' %}
   {% else %}


### PR DESCRIPTION
The default for big warehouse updated to XL from 4XL. Small warehouse remains as XS. Fixes #333 