### PR TITLE
updated_logic to tag the imputation value, method and dates

### DIFF
--- a/transform/models/intermediate/imputation/int_imputation__detector_imputed_agg_five_minutes.sql
+++ b/transform/models/intermediate/imputation/int_imputation__detector_imputed_agg_five_minutes.sql
@@ -37,19 +37,19 @@ hybrid_five_mins_agg as (
         station_valid_to,
         -- select the imputed value
         case
-            when detector_is_good = false
+            when detector_is_good = false or (detector_is_good = true and volume_sum is null)
                 then
                     coalesce(volume_local_regression, volume_regional_regression, volume_global_regression)
             else volume_sum
         end as volume_sum,
         case
-            when detector_is_good = false
+            when detector_is_good = false or (detector_is_good = true and speed_five_mins is null)
                 then
                     coalesce(speed_local_regression, speed_regional_regression, speed_global_regression)
             else speed_five_mins
         end as speed_five_mins,
         case
-            when detector_is_good = false
+            when detector_is_good = false or (detector_is_good = true and occupancy_avg is null)
                 then
                     coalesce(
                         occupancy_local_regression,
@@ -60,7 +60,11 @@ hybrid_five_mins_agg as (
         end as occupancy_avg,
         -- assign the imputation date
         case
-            when detector_is_good = false
+            when
+                detector_is_good = false
+                or (detector_is_good = true and volume_sum is null)
+                or (detector_is_good = true and occupancy_avg is null)
+                or (detector_is_good = true and speed_five_mins is null)
                 then
                     coalesce(local_regression_date, regional_regression_date, global_regression_date)
             else sample_date
@@ -72,10 +76,19 @@ hybrid_five_mins_agg as (
                 detector_is_good = false and volume_local_regression is not null
                 then 'local'
             when
+                detector_is_good = true and volume_sum is null and volume_local_regression is not null
+                then 'local'
+            when
                 detector_is_good = false and volume_regional_regression is not null
                 then 'regional'
             when
+                detector_is_good = true and volume_sum is null and volume_regional_regression is not null
+                then 'regional'
+            when
                 detector_is_good = false and volume_global_regression is not null
+                then 'global'
+            when
+                detector_is_good = true and volume_sum is null and volume_global_regression is not null
                 then 'global'
             else 'observed'
         end as volume_imputation_method,
@@ -84,10 +97,19 @@ hybrid_five_mins_agg as (
                 detector_is_good = false and speed_local_regression is not null
                 then 'local'
             when
+                detector_is_good = true and speed_five_mins is null and speed_local_regression is not null
+                then 'local'
+            when
                 detector_is_good = false and speed_regional_regression is not null
                 then 'regional'
             when
+                detector_is_good = true and speed_five_mins is null and speed_regional_regression is not null
+                then 'regional'
+            when
                 detector_is_good = false and speed_global_regression is not null
+                then 'global'
+            when
+                detector_is_good = true and speed_five_mins is null and speed_global_regression is not null
                 then 'global'
             else 'observed'
         end as speed_imputation_method,
@@ -96,7 +118,13 @@ hybrid_five_mins_agg as (
                 detector_is_good = false and occupancy_local_regression is not null
                 then 'local'
             when
+                detector_is_good = true and occupancy_avg is null and occupancy_local_regression is not null
+                then 'local'
+            when
                 detector_is_good = false and occupancy_regional_regression is not null
+                then 'regional'
+            when
+                detector_is_good = true and occupancy_avg is null and occupancy_local_regression is not null
                 then 'regional'
             when
                 detector_is_good = false and occupancy_global_regression is not null

--- a/transform/models/intermediate/imputation/int_imputation__detector_imputed_agg_five_minutes.sql
+++ b/transform/models/intermediate/imputation/int_imputation__detector_imputed_agg_five_minutes.sql
@@ -37,19 +37,19 @@ hybrid_five_mins_agg as (
         station_valid_to,
         -- select the imputed value
         case
-            when detector_is_good = false or (detector_is_good = true and volume_sum is null)
+            when detector_is_good = false or volume_sum is null
                 then
                     coalesce(volume_local_regression, volume_regional_regression, volume_global_regression)
             else volume_sum
         end as volume_sum,
         case
-            when detector_is_good = false or (detector_is_good = true and speed_five_mins is null)
+            when detector_is_good = false or speed_five_mins is null
                 then
                     coalesce(speed_local_regression, speed_regional_regression, speed_global_regression)
             else speed_five_mins
         end as speed_five_mins,
         case
-            when detector_is_good = false or (detector_is_good = true and occupancy_avg is null)
+            when detector_is_good = false or occupancy_avg is null
                 then
                     coalesce(
                         occupancy_local_regression,
@@ -62,9 +62,9 @@ hybrid_five_mins_agg as (
         case
             when
                 detector_is_good = false
-                or (detector_is_good = true and volume_sum is null)
-                or (detector_is_good = true and occupancy_avg is null)
-                or (detector_is_good = true and speed_five_mins is null)
+                or volume_sum is null
+                or occupancy_avg is null
+                or speed_five_mins is null
                 then
                     coalesce(local_regression_date, regional_regression_date, global_regression_date)
             else sample_date
@@ -73,61 +73,37 @@ hybrid_five_mins_agg as (
         -- assign the imputation method
         case
             when
-                detector_is_good = false and volume_local_regression is not null
+                (detector_is_good = false or volume_sum is null) and volume_local_regression is not null
                 then 'local'
             when
-                detector_is_good = true and volume_sum is null and volume_local_regression is not null
-                then 'local'
-            when
-                detector_is_good = false and volume_regional_regression is not null
+                (detector_is_good = false or volume_sum is null) and volume_regional_regression is not null
                 then 'regional'
             when
-                detector_is_good = true and volume_sum is null and volume_regional_regression is not null
-                then 'regional'
-            when
-                detector_is_good = false and volume_global_regression is not null
-                then 'global'
-            when
-                detector_is_good = true and volume_sum is null and volume_global_regression is not null
+                (detector_is_good = false or volume_sum is null) and volume_global_regression is not null
                 then 'global'
             else 'observed'
         end as volume_imputation_method,
         case
             when
-                detector_is_good = false and speed_local_regression is not null
+                (detector_is_good = false or speed_five_mins is null) and speed_local_regression is not null
                 then 'local'
             when
-                detector_is_good = true and speed_five_mins is null and speed_local_regression is not null
-                then 'local'
-            when
-                detector_is_good = false and speed_regional_regression is not null
+                (detector_is_good = false or speed_five_mins is null) and speed_regional_regression is not null
                 then 'regional'
             when
-                detector_is_good = true and speed_five_mins is null and speed_regional_regression is not null
-                then 'regional'
-            when
-                detector_is_good = false and speed_global_regression is not null
-                then 'global'
-            when
-                detector_is_good = true and speed_five_mins is null and speed_global_regression is not null
+                (detector_is_good = false or speed_five_mins is null) and speed_global_regression is not null
                 then 'global'
             else 'observed'
         end as speed_imputation_method,
         case
             when
-                detector_is_good = false and occupancy_local_regression is not null
+                (detector_is_good = false or occupancy_avg is null) and occupancy_local_regression is not null
                 then 'local'
             when
-                detector_is_good = true and occupancy_avg is null and occupancy_local_regression is not null
-                then 'local'
-            when
-                detector_is_good = false and occupancy_regional_regression is not null
+                (detector_is_good = false or occupancy_avg is null) and occupancy_regional_regression is not null
                 then 'regional'
             when
-                detector_is_good = true and occupancy_avg is null and occupancy_local_regression is not null
-                then 'regional'
-            when
-                detector_is_good = false and occupancy_global_regression is not null
+                (detector_is_good = false or occupancy_avg is null) and occupancy_global_regression is not null
                 then 'global'
             else 'observed'
         end as occupancy_imputation_method


### PR DESCRIPTION
This PR updated the imputation logic for the following case based on Fixes #326

1. Detector_is_good=false, impute volume, occupancy and speed
2. Detector_is_good=True, volume_sum is null, impute volume_sum
3. Detector_is_good=True, occupancy_avg is null, impute occupancy_avg
4. Detector_is_good=True, speed_five_mins is null, impute_five_mins_speed