### PR TITLE
Move profile config to avoid deprecation warning

### DIFF
--- a/transform/ci/profiles.yml
+++ b/transform/ci/profiles.yml
@@ -1,8 +1,3 @@
-config:
-  send_anonymous_usage_stats: false
-  use_colors: true
-  warn_error: true
-
 caltrans_pems:
   target: dev
   outputs:

--- a/transform/dbt_project.yml
+++ b/transform/dbt_project.yml
@@ -3,6 +3,11 @@ name: caldata_mdsa_caltrans_pems
 version: "1.0.0"
 config-version: 2
 
+flags:
+  send_anonymous_usage_stats: false
+  use_colors: true
+  warn_error: false
+
 # This setting configures which "profile" dbt uses for this project.
 profile: caltrans_pems
 


### PR DESCRIPTION


Docs build started [failing](https://github.com/cagov/caldata-mdsa-caltrans-pems/actions/runs/10307510120/job/28532925162) because dbt deprecated configuration in the `profiles.yml`. This moves it to the new location in `dbt_project.yml`