### PR TITLE
Updated imputation logic (replaced null speed with zero when volume and occupancy are zero)

### DIFF
--- a/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes.sql
+++ b/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes.sql
@@ -32,7 +32,7 @@ with base as (
             when volume_sum = 0 and occupancy_avg = 0 then 0
             else speed_weighted
         end as speed_weighted
-    from {{ ref('int_clearinghouse__detector_agg_five_minutes_with_missing_rows')}}
+    from {{ ref('int_clearinghouse__detector_agg_five_minutes_with_missing_rows') }}
     where {{ make_model_incremental('sample_date') }}
 ),
 

--- a/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes.sql
+++ b/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes.sql
@@ -9,7 +9,30 @@
 
 /* Unimputed data aggregated to five minutes" */
 with base as (
-    select * from {{ ref('int_clearinghouse__detector_agg_five_minutes') }}
+    select
+        station_id,
+        detector_id,
+        lane,
+        district,
+        sample_date,
+        sample_timestamp,
+        volume_sum,
+        occupancy_avg,
+        freeway,
+        direction,
+        county,
+        city,
+        length,
+        station_type,
+        absolute_postmile,
+        sample_ct,
+        station_valid_from,
+        station_valid_to,
+        case
+            when volume_sum = 0 and occupancy_avg = 0 then 0
+            else speed_weighted
+        end as speed_weighted
+    from {{ ref('int_clearinghouse__detector_agg_five_minutes') }}
     where {{ make_model_incremental('sample_date') }}
 ),
 


### PR DESCRIPTION
This PR replaced null speed with zero speed when volume is zero and occupancy is zero to reflect correct imputation application. Previously we imputed null speed due to zeros volume and occupancy which mislead the imputation application. In this PR, we corrected those. This PR related to issues #370