### PR TITLE
Update Normalized Flow and Imputation Methods

### DIFF
--- a/transform/models/intermediate/clearinghouse/_clearinghouse.yml
+++ b/transform/models/intermediate/clearinghouse/_clearinghouse.yml
@@ -106,9 +106,9 @@ models:
       - name: lane
         description: |
           Lane associated with a route and station from raw data.
+      - name: volume_observed
+        description: Number of vehicles that passed over the detector during the sample period for the lane.
       - name: volume_sum
-        description: Number of vehicle that passed over the detector during the sample period for the lane.
-      - name: volume_normalized
         description: |
           For the 5-minute aggregation there should be 10 30-second samples collected. If 10 or more
           samples are collected the aggregated (sum) volume rounded to the nearest integer value is used

--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes.sql
@@ -87,7 +87,9 @@ agg as (
                 sample_ct_{{ lane }} >= 10, volume_{{ lane }},
                 10 / nullifzero(sample_ct_{{ lane }}) * volume_{{ lane }}
             ))
-                as volume_sum, --Represents the normalized flow value
+                as volume_sum,
+                --Represents the observed or normalized flow value based on the
+                --number of samples recieved by the device
             zero_vol_ct_{{ lane }} as zero_vol_ct,
             occupancy_{{ lane }} as occupancy_avg,
             zero_occ_ct_{{ lane }} as zero_occ_ct,

--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes.sql
@@ -82,12 +82,12 @@ agg as (
             district,
             sample_ct_{{ lane }} as sample_ct,
             {{ lane }} as lane,
-            volume_{{ lane }} as volume_sum,
+            volume_{{ lane }} as volume_observed,
             round(iff(
                 sample_ct_{{ lane }} >= 10, volume_{{ lane }},
                 10 / nullifzero(sample_ct_{{ lane }}) * volume_{{ lane }}
             ))
-                as volume_normalized,
+                as volume_sum, --Represents the normalized flow value
             zero_vol_ct_{{ lane }} as zero_vol_ct,
             occupancy_{{ lane }} as occupancy_avg,
             zero_occ_ct_{{ lane }} as zero_occ_ct,

--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes_with_missing_rows.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes_with_missing_rows.sql
@@ -57,7 +57,7 @@ base as (
         agg.high_volume_ct,
         agg.high_occupancy_ct,
         agg.speed_weighted,
-        agg.volume_normalized,
+        agg.volume_observed,
         coalesce(agg.state_postmile, dmeta.state_postmile) as state_postmile,
         coalesce(agg.absolute_postmile, dmeta.absolute_postmile) as absolute_postmile,
         coalesce(agg.latitude, dmeta.latitude) as latitude,

--- a/transform/models/intermediate/performance/_performance.yml
+++ b/transform/models/intermediate/performance/_performance.yml
@@ -83,13 +83,19 @@ models:
           maximum observed 15-minute flow. We use the maximum of this value and 2076 v/l/h
           as the capacity at each location. The threshold values used are 35, 40, 45, 50, 55,
           and 60 MPH.
-      - name: int_performance__station_metrics_agg_hourly
-        description: |
-          hourly aggregation of volume, occupancy and speed along with delays and lost productivity by
-          each station regardless of lanes. This metrics will measure the hourly performance of the state
-          highway system at the station level.This can be used for daily aggregation of PeMS performance
-          metrics at the station level.
-          columns:
+      - name: speed_imputation_method
+        description: The method (local/regional/global) used to impute the speed.
+      - name: volume_imputation_method
+        description: The method (local/regional/global) used to impute the volume.
+      - name: occupancy_imputation_method
+        description: The method (local/regional/global) used to impute the occupancy.
+  - name: int_performance__station_metrics_agg_hourly
+    description: |
+      hourly aggregation of volume, occupancy and speed along with delays and lost productivity by
+      each station regardless of lanes. This metrics will measure the hourly performance of the state
+      highway system at the station level.This can be used for daily aggregation of PeMS performance
+      metrics at the station level.
+    columns:
       - name: ID
         description: |
           An integer value that uniquely indentifies a station.

--- a/transform/models/intermediate/performance/int_performance__detector_metrics_agg_five_minutes.sql
+++ b/transform/models/intermediate/performance/int_performance__detector_metrics_agg_five_minutes.sql
@@ -24,6 +24,9 @@ five_minute_agg as (
         occupancy_avg,
         speed_five_mins as speed_weighted,
         station_type,
+        volume_imputation_method,
+        speed_imputation_method,
+        occupancy_imputation_method,
         station_valid_from,
         station_valid_to
     from {{ ref('int_imputation__detector_imputed_agg_five_minutes') }}


### PR DESCRIPTION
The volume_sum field has been updated to use the normalized flow instead of the observed flow to account for any missing samples. I have also added the imputation method columns to the 5-minute aggregate detector performance model for use in reporting/visualization. This will require a full data refresh once the PR is merged. 