### PR TITLE
Tr update pre commit checks 217

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,14 +26,6 @@ jobs:
         # just use $SNOWFLAKE_PRIVATE_KEY
       - name: Set up private key
         run: echo "$PRIVATE_KEY" > $SNOWFLAKE_PRIVATE_KEY_PATH
-      - name: Setup terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: v1.4.0
-      - name: Install tflint
-        run: |
-          curl -s https://raw.githubusercontent.com/terraform-linters/\
-          tflint/master/install_linux.sh | bash
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"

--- a/.github/workflows/terraform-checks.yml
+++ b/.github/workflows/terraform-checks.yml
@@ -1,4 +1,4 @@
-name: terraform
+name: terraform-checks
 
 on:
   pull_request:
@@ -12,7 +12,7 @@ env:
   SNOWFLAKE_PRIVATE_KEY_PATH: /tmp/private_key.p8
 
 jobs:
-  pre-commit:
+  terraform-checks:
     runs-on: ubuntu-latest
     steps:      
       - uses: actions/checkout@v3
@@ -27,3 +27,9 @@ jobs:
       - name: Run terraform fmt
         run: |
           terraform fmt
+      - name: Run terraform validate
+        run: |
+          terraform validate
+      - name: Run terraform tflint
+        run: |
+          tflint

--- a/.github/workflows/terraform-checks.yml
+++ b/.github/workflows/terraform-checks.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   terraform-checks:
     runs-on: ubuntu-latest
-    steps:      
+    steps:
       - uses: actions/checkout@v3
       - name: Setup terraform
         uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/terraform-checks.yml
+++ b/.github/workflows/terraform-checks.yml
@@ -5,8 +5,8 @@ on:
   push:
     branches: [main,tr_update_pre_commit_checks_217]
 
-env:
-  TFLINT_LOG: debug
+##env:
+##  TFLINT_LOG: debug
 
 jobs:
   terraform-checks:

--- a/.github/workflows/terraform-checks.yml
+++ b/.github/workflows/terraform-checks.yml
@@ -3,7 +3,7 @@ name: terraform-checks
 on:
   pull_request:
   push:
-    branches: [main,tr_update_pre_commit_checks_217]
+    branches: [main]
 
 ##env:
 ##  TFLINT_LOG: debug

--- a/.github/workflows/terraform-checks.yml
+++ b/.github/workflows/terraform-checks.yml
@@ -32,4 +32,4 @@ jobs:
           terraform validate
       - name: Run terraform tflint
         run: |
-          tflint
+          tflint --chdir=terraform/

--- a/.github/workflows/terraform-checks.yml
+++ b/.github/workflows/terraform-checks.yml
@@ -6,10 +6,7 @@ on:
     branches: [main,tr_update_pre_commit_checks_217]
 
 env:
-  PRIVATE_KEY: ${{ SECRETS.SNOWFLAKE_PRIVATE_KEY_DEV }}
-  SNOWFLAKE_USER: ${{ SECRETS.SNOWFLAKE_USER_DEV }}
-  SNOWFLAKE_ACCOUNT: ${{ SECRETS.SNOWFLAKE_ACCOUNT }}
-  SNOWFLAKE_PRIVATE_KEY_PATH: /tmp/private_key.p8
+  TFLINT_LOG: debug
 
 jobs:
   terraform-checks:

--- a/.github/workflows/terraform-checks.yml
+++ b/.github/workflows/terraform-checks.yml
@@ -32,4 +32,4 @@ jobs:
           terraform validate
       - name: Run terraform tflint
         run: |
-          tflint --chdir=terraform/
+          tflint --chdir=terraform/ --recursive

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,29 @@
+name: terraform
+
+on:
+  pull_request:
+  push:
+    branches: [main,tr_update_pre_commit_checks_217]
+
+env:
+  PRIVATE_KEY: ${{ SECRETS.SNOWFLAKE_PRIVATE_KEY_DEV }}
+  SNOWFLAKE_USER: ${{ SECRETS.SNOWFLAKE_USER_DEV }}
+  SNOWFLAKE_ACCOUNT: ${{ SECRETS.SNOWFLAKE_ACCOUNT }}
+  SNOWFLAKE_PRIVATE_KEY_PATH: /tmp/private_key.p8
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:      
+      - uses: actions/checkout@v3
+      - name: Setup terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: v1.4.0
+      - name: Install tflint
+        run: |
+          curl -s https://raw.githubusercontent.com/terraform-linters/\
+          tflint/master/install_linux.sh | bash
+      - name: Run terraform fmt
+        run: |
+          terraform fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,15 +19,6 @@ repos:
     hooks:
       - id: yamllint
         args: []
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.1
-    hooks:
-      - id: terraform_fmt
-      - id: terraform_validate
-        # Exclude modules to work around
-        # https://github.com/hashicorp/terraform/issues/28490
-        exclude: "terraform/modules/[^/]+/[^/]+$"
-      - id: terraform_tflint
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.1.6
     hooks:


### PR DESCRIPTION
Current precommit checks require terraform installed locally, most developers don't need terraform so we should not require it as part of precommit checks.

This pr resolves this issue.
Closes #247 