### PR TITLE
Updated all imputation model with normalized volume

### DIFF
--- a/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes.sql
+++ b/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes.sql
@@ -16,7 +16,7 @@ with base as (
         district,
         sample_date,
         sample_timestamp,
-        volume_sum,
+        volume_normalized as volume_sum,
         occupancy_avg,
         freeway,
         direction,
@@ -29,7 +29,7 @@ with base as (
         station_valid_from,
         station_valid_to,
         case
-            when volume_sum = 0 and occupancy_avg = 0 then 0
+            when volume_normalized = 0 and occupancy_avg = 0 then 0
             else speed_weighted
         end as speed_weighted
     from {{ ref('int_clearinghouse__detector_agg_five_minutes_with_missing_rows') }}

--- a/transform/models/intermediate/imputation/int_imputation__global_coefficients.sql
+++ b/transform/models/intermediate/imputation/int_imputation__global_coefficients.sql
@@ -46,7 +46,7 @@ good_detectors as (
 ),
 
 agg as (
-    select * from {{ ref('int_clearinghouse__detector_agg_five_minutes') }}
+    select * from {{ ref('int_clearinghouse__detector_agg_five_minutes_with_missing_rows') }}
 ),
 
 /* Get the five-minute unimputed data. This is joined on the
@@ -60,7 +60,7 @@ detector_counts as (
         agg.lane,
         agg.sample_date,
         agg.sample_timestamp,
-        agg.volume_sum,
+        agg.volume_normalized as volume_sum,
         agg.occupancy_avg,
         agg.speed_weighted,
         agg.district,
@@ -68,7 +68,7 @@ detector_counts as (
         agg.direction,
         agg.station_type,
         -- TODO: Can we give this a better name? Can we move this into the base model?
-        coalesce(agg.speed_weighted, (agg.volume_sum * 22) / nullifzero(agg.occupancy_avg) * (1 / 5280) * 12)
+        coalesce(agg.speed_weighted, (volume_sum * 22) / nullifzero(agg.occupancy_avg) * (1 / 5280) * 12)
             as speed_five_mins,
         regression_dates_to_evaluate.regression_date
     from agg

--- a/transform/models/intermediate/imputation/int_imputation__local_regional_regression_coefficients.sql
+++ b/transform/models/intermediate/imputation/int_imputation__local_regional_regression_coefficients.sql
@@ -36,7 +36,7 @@ regression_dates_to_evaluate as (
 
 agg as (
     select *
-    from {{ ref('int_clearinghouse__detector_agg_five_minutes') }}
+    from {{ ref('int_clearinghouse__detector_agg_five_minutes_with_missing_rows') }}
 ),
 
 -- Select all station pairs that are active for the chosen regression dates
@@ -82,12 +82,12 @@ detector_counts as (
         agg.lane,
         agg.sample_date,
         agg.sample_timestamp,
-        agg.volume_sum,
+        agg.volume_normalized as volume_sum,
         agg.occupancy_avg,
         agg.speed_weighted,
         good_detectors.district,
         -- TODO: Can we give this a better name? Can we move this into the base model?
-        coalesce(agg.speed_weighted, (agg.volume_sum * 22) / nullifzero(agg.occupancy_avg) * (1 / 5280) * 12)
+        coalesce(agg.speed_weighted, (volume_sum * 22) / nullifzero(agg.occupancy_avg) * (1 / 5280) * 12)
             as speed_five_mins,
         regression_dates_to_evaluate.regression_date
     from agg


### PR DESCRIPTION
This PR updated all imputation model with normalized volume, also updated the source model from 'int_clearinghouse__detector_agg_five_minutes' to "int_clearinghouse__detector_agg_five_minutes_with_missing_rows' based on recent update. 