### PR TITLE
Update Station 5-minute Aggregation Model with Performance Metrics

### DIFF
--- a/transform/models/intermediate/performance/int_performance__max_capacity.sql
+++ b/transform/models/intermediate/performance/int_performance__max_capacity.sql
@@ -29,7 +29,7 @@ max_capacity_detector as (
         */
         173 as max_capacity_5min
     from source
-    group by detector_id, station_id, physical_lanes
+    group by detector_id
 )
 
 select * from max_capacity_detector

--- a/transform/models/intermediate/performance/int_performance__max_capacity.sql
+++ b/transform/models/intermediate/performance/int_performance__max_capacity.sql
@@ -1,40 +1,35 @@
 /*
-This model develops the maximum capacity of a detector based on the historical measured
-raw data and determines the maximum observed 15-minute flow. We use the maximum of the
-actual 15-minute flow value and 2076 v/l/h as the capacity at each location. This will be used
-to determine the productivity performance metric.
+This model currently uses a maximum capacity of 2076 vehicles/lane/hour for all detectors.
+Using this value provides a consistent metric for determining the capcacity and
+calculating the lost productivity.
+
+The current methodology in PeMS uses the max of either the 15 minute historical highest
+flow or 2076 v/l/h as the capacity at each location per PeMS website:
+https://pems.dot.ca.gov/?dnode=Help&content=help_calc#perf
+
+The issue with the current methodology is that there is no documentation for how the historical
+measured maximum capacity has been developed and we have observed inconsistencies in high flow
+values in PeMS. We also do not have any documention on why a 15-minute timeframe was selected
+and how that value is used to compute the 5-minute aggregation level of the lost productivity
+performance metric.
 */
 
 with
 
 source as (
     select *
-    from {{ ref('int_imputation__detector_imputed_agg_five_minutes') }}
+    from {{ ref('int_vds__detector_config') }}
 ),
 
-sum_volume as (
-    select
-        *,
-        sum(volume_sum)
-        /* we are looking at a window of 3 rows because that is a 15-minute window
-        (5-min data * 3 = 15 minutes) */
-            over (
-                partition by detector_id, sample_date
-                order by sample_timestamp rows between 2 preceding and current row
-            )
-            as volume_summed
+max_capacity_detector as (
+    select distinct
+        detector_id,
+        /*
+        2076 v/l/h / 12 = 173 v/l/5-min
+        */
+        173 as max_capacity_5min
     from source
-    qualify volume_sum is not null
+    group by detector_id, station_id, physical_lanes
 )
 
-select
-    detector_id,
-    /*
-    Use max of 2076 v/l/h or 15 minute historical highest flow as the capacity
-    at each location per PeMS website:
-    https://pems.dot.ca.gov/?dnode=Help&content=help_calc#perf
-    2076 v/l/h / 12 = 173 v/l/5-min
-    */
-    greatest(max(volume_summed), 173) as max_capacity_5min
-from sum_volume
-group by all
+select * from max_capacity_detector

--- a/transform/models/intermediate/performance/int_performance__max_capacity.sql
+++ b/transform/models/intermediate/performance/int_performance__max_capacity.sql
@@ -29,7 +29,6 @@ max_capacity_detector as (
         */
         173 as max_capacity_5min
     from source
-    group by detector_id
 )
 
 select * from max_capacity_detector

--- a/transform/models/intermediate/performance/int_performance__station_metrics_agg_five_minutes.sql
+++ b/transform/models/intermediate/performance/int_performance__station_metrics_agg_five_minutes.sql
@@ -8,11 +8,11 @@
 
 with detector_agg_five_minutes as (
     select *
-    from {{ ref('int_imputation__detector_imputed_agg_five_minutes') }}
+    from {{ ref('int_performance__detector_metrics_agg_five_minutes') }}
     where {{ make_model_incremental('sample_date') }}
 ),
 
-station_aggregated_speed as (
+station_aggregated as (
     select
         station_id,
         sample_date,
@@ -20,15 +20,39 @@ station_aggregated_speed as (
         any_value(freeway) as freeway,
         any_value(direction) as direction,
         any_value(station_type) as station_type,
-        any_value(absolute_postmile) as absolute_postmile,
         any_value(district) as district,
+        any_value(county) as county,
+        any_value(city) as city,
         any_value(length) as length,
+        any_value(station_valid_from) as station_valid_from,
+        any_value(station_valid_to) as station_valid_to,
+        round(sum(vmt), 1) as vmt,
+        round(sum(vht), 2) as vht,
         sum(sample_ct) as sample_ct,
-        sum(volume_sum) as volume_sum,
-        avg(occupancy_avg) as occupancy_avg,
-        sum(volume_sum * speed_five_mins) / nullifzero(sum(volume_sum)) as speed_five_mins
+        round(sum(volume_sum), 0) as volume_sum,
+        round(avg(occupancy_avg), 4) as occupancy_avg,
+        round(sum(volume_sum * speed_five_mins) / nullifzero(sum(volume_sum)), 1) as speed_five_mins,
+        {% for value in var("V_t") %}
+            round(sum(lost_productivity_{{ value }}_mph), 2) as lost_productivity_{{ value }}_mph
+            {% if not loop.last %}
+                ,
+            {% endif %}
+        {% endfor %}
     from detector_agg_five_minutes
     group by station_id, sample_date, sample_timestamp
+),
+
+station_aggregated_with_delay as (
+    select
+        *,
+        {% for value in var("V_t") %}
+            round(greatest(volume_sum * ((length / nullifzero(speed_five_mins)) - (length / {{ value }})), 0), 2)
+                as delay_{{ value }}_mph
+            {% if not loop.last %}
+                ,
+            {% endif %}
+        {% endfor %}
+    from station_aggregated
 )
 
-select * from station_aggregated_speed
+select * from station_aggregated_with_delay


### PR DESCRIPTION
Update max_capacity model to use a consistent value of 173 vehicles/lane/5-minute for each detector's max capacity. Also, update station 5-minute aggregation model with performance metrics. This fixes #380.