### PR TITLE
add absolute_postmile variable to support bottleneck calcs

### DIFF
--- a/transform/models/intermediate/performance/int_performance__detector_metrics_agg_five_minutes.sql
+++ b/transform/models/intermediate/performance/int_performance__detector_metrics_agg_five_minutes.sql
@@ -2,6 +2,7 @@
     materialized="incremental",
     cluster_by=["sample_date"],
     unique_key=["detector_id", "sample_timestamp"],
+    on_schema_change="sync_all_columns",
     snowflake_warehouse = get_snowflake_refresh_warehouse(small="XL")
 ) }}
 

--- a/transform/models/intermediate/performance/int_performance__detector_metrics_agg_five_minutes.sql
+++ b/transform/models/intermediate/performance/int_performance__detector_metrics_agg_five_minutes.sql
@@ -24,6 +24,7 @@ five_minute_agg as (
         occupancy_avg,
         speed_five_mins as speed_weighted,
         station_type,
+        absolute_postmile,
         volume_imputation_method,
         speed_imputation_method,
         occupancy_imputation_method,

--- a/transform/models/intermediate/performance/int_performance__station_metrics_agg_five_minutes.sql
+++ b/transform/models/intermediate/performance/int_performance__station_metrics_agg_five_minutes.sql
@@ -17,6 +17,7 @@ station_aggregated as (
         station_id,
         sample_date,
         sample_timestamp,
+        any_value(absolute_postmile) as absolute_postmile,
         any_value(freeway) as freeway,
         any_value(direction) as direction,
         any_value(station_type) as station_type,


### PR DESCRIPTION
This pr fixes an error caused by `int_performance__bottlenecks` using absolute_postmile, which was removed in 5bb358b6b33b016d4084c8424a8c99e531d49dd6. 
