### PR TITLE
enable udfs as macros

### DIFF
--- a/transform/dbt_project.yml
+++ b/transform/dbt_project.yml
@@ -96,3 +96,6 @@ models:
       geo:
         +schema: geo
         +post-hook: "{{ unload_relation_as_geojson(strip_leading_words=1) }}"
+
+on-run-start:
+  - "{{create_udfs()}}"

--- a/transform/macros/create_udfs.sql
+++ b/transform/macros/create_udfs.sql
@@ -1,0 +1,5 @@
+{% macro create_udfs() %}
+
+    {{ create_exponential_smoothing_function() }};
+
+{% endmacro %}

--- a/transform/macros/exponential_smoothing.sql
+++ b/transform/macros/exponential_smoothing.sql
@@ -1,0 +1,25 @@
+{% macro create_exponential_smoothing_function() %}
+
+CREATE OR REPLACE FUNCTION {{ target.database }}.public.exponential_smooth("VALUE" FLOAT, "FACTOR" FLOAT)
+RETURNS TABLE ("VALUE_SMOOTHED" FLOAT)
+LANGUAGE PYTHON
+RUNTIME_VERSION = '3.11'
+HANDLER = 'Smoother'
+AS $$
+class Smoother:
+    def __init__(self):
+        self.previous_value = None
+
+    def process(self, value, factor):
+        if value is None or factor is None:
+            yield_value = None
+        else:
+            # If previous value was null, substitute current value.
+            previous_value = self.previous_value if self.previous_value is not None else value
+            yield_value = value * factor + (1-factor) * previous_value
+
+        self.previous_value = yield_value
+        yield (yield_value,)
+$$
+
+{% endmacro %}


### PR DESCRIPTION
1. Added `create_udfs` macro that gets called [on-run-start](https://docs.getdbt.com/reference/project-configs/on-run-start-on-run-end)
2. Added exponential smoothing udtf for use in #402 

Example udtf usage:
```sql
select
    detector_id,
    sample_timestamp,
    speed_preliminary,
    res.value_smoothed as speed_smoothed,
    p_factor
from
     int_clearinghouse__detector_g_factor_based_speed,
     TABLE(public.exponential_smooth(speed_preliminary, p_factor::float)
       OVER (PARTITION BY detector_id order by sample_timestamp)) AS res
```