### PR TITLE
Update 5 min clearinghouse and Detector Status Models

### DIFF
--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes_with_missing_rows.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes_with_missing_rows.sql
@@ -24,7 +24,6 @@ detector_meta as (
 
 /*
  * Get date range where a detector is expected to be collecting data.
- * This could pull from the active stations model instead?
  */
 detector_date_range as (
     select

--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes_with_missing_rows.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes_with_missing_rows.sql
@@ -29,10 +29,9 @@ detector_meta as (
 detector_date_range as (
     select
         detector_id,
-        min(sample_date) as min_date,
-        max(sample_date) as max_date
-    from detector_agg
-    group by detector_id
+        active_date
+    from {{ ref('int_vds__active_detectors') }}
+    where {{ make_model_incremental('active_date') }}
 ),
 
 /* Expand timestamp spine to include values per detector but only for days within the detector's date range */
@@ -41,7 +40,7 @@ spine as (
         ts.timestamp_column,
         dd.detector_id
     from timestamp_spine as ts inner join detector_date_range as dd
-        on to_date(ts.timestamp_column) >= dd.min_date and to_date(ts.timestamp_column) <= dd.max_date
+        on to_date(ts.timestamp_column) = dd.active_date
 ),
 
 /* Join 5-minute aggregated data to the spine to get a table without missing rows */

--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes_with_missing_rows.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes_with_missing_rows.sql
@@ -7,7 +7,7 @@
 ) }}
 
 with timestamp_spine as (
-    {{ timestamp_spine(start_date="'1998-10-01'",
+    {{ timestamp_spine(start_date="'2023-01-01'",
         end_date="current_date()",
         second_increment=60*5
     ) }}
@@ -31,7 +31,6 @@ detector_date_range as (
         detector_id,
         active_date
     from {{ ref('int_vds__active_detectors') }}
-    where {{ make_model_incremental('active_date') }}
 ),
 
 /* Expand timestamp spine to include values per detector but only for days within the detector's date range */

--- a/transform/models/intermediate/diagnostics/_diagnostics.yml
+++ b/transform/models/intermediate/diagnostics/_diagnostics.yml
@@ -224,23 +224,23 @@ models:
       - name: controller_id
         description: |
           The controller identifier value provided in the district configuration file.
-      - name: district_feed_working.
+      - name: district_feed_working
         description: |
           Returns No if no detector samples are recieved in a district on a daily basis, otherwise
           Yes is returned.
       - name: line_num_working
         description: |
-          Returns No if no detector samples are recieved on a communication line associated with a 
+          Returns No if no detector samples are recieved on a communication line associated with a
           specific line and district on a daily basis, otherwise Yes is returned.
       - name: controller_feed_working
         description: |
           Returns No if no detector samples are recieved from a controller on a daily basis,
-          otherwise Yes is returned
+          otherwise Yes is returned.
       - name: station_feed_working
         description: |
           Returns No if no detector samples are recieved from a station on a daily basis,
-          otherwise Yes is returned
+          otherwise Yes is returned.
       - name: detector_feed_working
         description: |
-          Returns No if a detector send no samples to PeMS on a daily basis, otherwise Yes is 
-          returned
+          Returns No if a detector send no samples to PeMS on a daily basis, otherwise Yes is
+          returned.

--- a/transform/models/intermediate/diagnostics/_diagnostics.yml
+++ b/transform/models/intermediate/diagnostics/_diagnostics.yml
@@ -185,3 +185,62 @@ models:
           Selects the minimum of the abs_val_occupancy_delta_summed column
           which takes the absolute value of the delta between occupancy and
           previous occupancy summed over a window of 4 hours.
+
+  - name: int_diagnostics__no_data_status
+    description: |
+      This data model is built to perform diagnostic tests related to equipment where no data is being
+      recieved from field devices. The diagnostic checks in this data model are used to determine the
+      detector status in the downstream int_diagnostics__detector_status model.
+    columns:
+      - name: active_date
+        description: |
+          Date a station is considered active based on the meta data configuration file from district.
+          This value determines what calculations or diagnostics are associated with a station and it's
+          assocaited detectors on any given date while it is active.
+        tests:
+          - not_null
+      - name: district
+        description: The Caltrans district associated with the detector.
+      - name: station_id
+        description: |
+          An integer value that uniquely indentifies a station.
+          Use this value to 'join' other files or tables that contain the Station ID value.
+        tests:
+          - not_null
+      - name: detector_id
+        description: |
+          The detector ID. In general, there can be several detectors for a single
+          station, corresponding to different lanes of traffic.
+        tests:
+          - not_null
+      - name: line_num
+        description: |
+          The communication line identifier value provided in the district configuration file. Information
+          about communication lines is not always available so this value can be null.
+      - name: sample_ct
+        description: |
+          Counts the number of raw data samples where a lane's volume (flow) and occupancy
+          values contain any non-null value.
+      - name: controller_id
+        description: |
+          The controller identifier value provided in the district configuration file.
+      - name: district_feed_working.
+        description: |
+          Returns No if no detector samples are recieved in a district on a daily basis, otherwise
+          Yes is returned.
+      - name: line_num_working
+        description: |
+          Returns No if no detector samples are recieved on a communication line associated with a 
+          specific line and district on a daily basis, otherwise Yes is returned.
+      - name: controller_feed_working
+        description: |
+          Returns No if no detector samples are recieved from a controller on a daily basis,
+          otherwise Yes is returned
+      - name: station_feed_working
+        description: |
+          Returns No if no detector samples are recieved from a station on a daily basis,
+          otherwise Yes is returned
+      - name: detector_feed_working
+        description: |
+          Returns No if a detector send no samples to PeMS on a daily basis, otherwise Yes is 
+          returned

--- a/transform/models/intermediate/diagnostics/int_diagnostics__detector_status.sql
+++ b/transform/models/intermediate/diagnostics/int_diagnostics__detector_status.sql
@@ -1,13 +1,12 @@
 {{ config(
     materialized="incremental",
-    cluster_by=['sample_date'],
-    unique_key=['station_id', 'lane', 'sample_date'],
-    on_schema_change='sync_all_columns',
+    cluster_by=["sample_date"],
+    unique_key=["station_id", "lane", "sample_date"],
+    on_schema_change="sync_all_columns",
     snowflake_warehouse=get_snowflake_refresh_warehouse(small="XL")
 ) }}
 
 with
-
 source as (
     select * from {{ ref('int_diagnostics__samples_per_detector') }}
     where {{ make_model_incremental('sample_date') }}
@@ -17,26 +16,9 @@ detector_meta as (
     select * from {{ ref('int_vds__detector_config') }}
 ),
 
-district_feed_check as (
+assignment_with_meta as (
     select
-        source.district,
-        case
-            when (count_if(source.sample_ct > 0)) > 0 then 'Yes'
-            else 'No'
-        end as district_feed_working
-    from source
-    inner join {{ ref('districts') }} as d
-        on source.district = d.district_id
-    group by source.district
-),
-
-detector_status as (
-    select
-        set_assgnmt.active_date,
-        set_assgnmt.station_id,
-        set_assgnmt.district,
-        set_assgnmt.station_type,
-        set_assgnmt.active_date as sample_date,
+        set_assgnmt.*,
         dm.detector_id,
         dm.detector_type,
         dm.lane,
@@ -49,12 +31,48 @@ detector_status as (
         dm.city,
         dm.freeway,
         dm.direction,
-        dm.length,
+        dm.length
+    from {{ ref('int_diagnostics__det_diag_set_assignment') }} as set_assgnmt
+    inner join detector_meta as dm
+        on
+            set_assgnmt.station_id = dm.station_id
+            and {{ get_scd_2_data('set_assgnmt.active_date','dm._valid_from','dm._valid_to') }}
+),
+
+detector_status as (
+    select
+        awm.active_date,
+        awm.station_id,
+        awm.district,
+        awm.station_type,
+        awm.station_diagnostic_method_id,
+        awm.active_date as sample_date,
+        awm.detector_id,
+        awm.detector_type,
+        awm.lane,
+        awm.state_postmile,
+        awm.absolute_postmile,
+        awm.latitude,
+        awm.longitude,
+        awm.physical_lanes,
+        awm.county,
+        awm.city,
+        awm.freeway,
+        awm.direction,
+        awm.length,
         sps.* exclude (district, station_id, lane, detector_id, sample_date),
-        dfc.district_feed_working,
+        nds.district_feed_working,
+        nds.line_num_working,
+        nds.controller_feed_working,
+        nds.station_feed_working,
+        nds.detector_feed_working,
         co.min_occupancy_delta,
         case
-            when dfc.district_feed_working = 'No' then 'District Feed Down'
+            when nds.district_feed_working = 'No' then 'District Feed Down'
+            when nds.line_num_working = 'No' then 'Line Down'
+            when nds.controller_feed_working = 'No' then 'Controller Down'
+            when nds.station_feed_working = 'No' then 'Station Down'
+            when nds.detector_feed_working = 'No' then 'No Data'
             when sps.sample_ct = 0 or sps.sample_ct is null
                 then 'Down/No Data'
             /* # of samples < 60% of the max collected during the test period
@@ -63,63 +81,61 @@ detector_status as (
             when sps.sample_ct between 1 and (0.6 * ({{ var("detector_status_max_sample_value") }}))
                 then 'Insufficient Data'
             when
-                set_assgnmt.station_diagnostic_method_id = 'ramp'
+                awm.station_diagnostic_method_id = 'ramp'
                 and sps.zero_vol_ct / ({{ var("detector_status_max_sample_value") }})
-                > (set_assgnmt.zero_flow_percent / 100)
+                > (awm.zero_flow_percent / 100)
                 then 'Card Off'
             when
-                set_assgnmt.station_diagnostic_method_id = 'mainline'
+                awm.station_diagnostic_method_id = 'mainline'
                 and sps.zero_occ_ct / ({{ var("detector_status_max_sample_value") }})
-                > (set_assgnmt.zero_occupancy_percent / 100)
+                > (awm.zero_occupancy_percent / 100)
                 then 'Card Off'
             when
-                set_assgnmt.station_diagnostic_method_id = 'ramp'
+                awm.station_diagnostic_method_id = 'ramp'
                 and sps.high_volume_ct / ({{ var("detector_status_max_sample_value") }})
-                > (set_assgnmt.high_flow_percent / 100)
+                > (awm.high_flow_percent / 100)
                 then 'High Val'
             when
-                set_assgnmt.station_diagnostic_method_id = 'mainline'
+                awm.station_diagnostic_method_id = 'mainline'
                 and sps.high_occupancy_ct / ({{ var("detector_status_max_sample_value") }})
-                > (set_assgnmt.high_occupancy_percent / 100)
+                > (awm.high_occupancy_percent / 100)
                 then 'High Val'
             when
-                set_assgnmt.station_diagnostic_method_id = 'mainline'
+                awm.station_diagnostic_method_id = 'mainline'
                 and sps.zero_vol_pos_occ_ct / ({{ var("detector_status_max_sample_value") }})
-                > (set_assgnmt.flow_occupancy_percent / 100)
+                > (awm.flow_occupancy_percent / 100)
                 then 'Intermittent'
             when
-                set_assgnmt.station_diagnostic_method_id = 'mainline'
+                awm.station_diagnostic_method_id = 'mainline'
                 and sps.zero_occ_pos_vol_ct / ({{ var("detector_status_max_sample_value") }})
-                > (set_assgnmt.occupancy_flow_percent / 100)
+                > (awm.occupancy_flow_percent / 100)
                 then 'Intermittent'
             when
                 coalesce(co.min_occupancy_delta = 0, false)
-                and set_assgnmt.station_diagnostic_method_id = 'mainline'
+                and awm.station_diagnostic_method_id = 'mainline'
                 then 'Constant'
             --Feed unstable case needed
             else 'Good'
         end as status
 
-    from {{ ref('int_diagnostics__det_diag_set_assignment') }} as set_assgnmt
-    inner join detector_meta as dm
-        on
-            set_assgnmt.station_id = dm.station_id
-            and {{ get_scd_2_data('set_assgnmt.active_date','dm._valid_from','dm._valid_to') }}
+    from assignment_with_meta as awm
 
     left join source as sps
         on
-            set_assgnmt.station_id = sps.station_id
-            and dm.lane = sps.lane
-            and set_assgnmt.active_date = sps.sample_date
+            awm.station_id = sps.station_id
+            and awm.lane = sps.lane
+            and awm.active_date = sps.sample_date
 
     left join {{ ref('int_diagnostics__constant_occupancy') }} as co
         on
-            set_assgnmt.station_id = co.station_id
+            awm.station_id = co.station_id
             and sps.lane = co.lane
-            and set_assgnmt.active_date = co.sample_date
+            and awm.active_date = co.sample_date
 
-    left join district_feed_check as dfc
-        on set_assgnmt.district = dfc.district
+    left join {{ ref('int_diagnostics__no_data_status') }} as nds
+        on
+            awm.active_date = nds.active_date
+            and awm.detector_id = nds.detector_id
 )
 
 select * from detector_status

--- a/transform/models/intermediate/diagnostics/int_diagnostics__detector_status.sql
+++ b/transform/models/intermediate/diagnostics/int_diagnostics__detector_status.sql
@@ -38,6 +38,7 @@ detector_status as (
         set_assgnmt.station_type,
         set_assgnmt.active_date as sample_date,
         dm.detector_id,
+        dm.detector_type,
         dm.lane,
         dm.state_postmile,
         dm.absolute_postmile,

--- a/transform/models/intermediate/diagnostics/int_diagnostics__detector_status.sql
+++ b/transform/models/intermediate/diagnostics/int_diagnostics__detector_status.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized="incremental",
     cluster_by=["sample_date"],
-    unique_key=["station_id", "lane", "sample_date"],
+    unique_key=["detector_id", "sample_date"],
     on_schema_change="sync_all_columns",
     snowflake_warehouse=get_snowflake_refresh_warehouse(small="XL")
 ) }}
@@ -122,8 +122,8 @@ detector_status as (
 
     left join source as sps
         on
-            awm.station_id = sps.station_id
-            and awm.lane = sps.lane
+            awm.detector_id = sps.detector_id
+            -- and awm.lane = sps.lane
             and awm.active_date = sps.sample_date
 
     left join {{ ref('int_diagnostics__constant_occupancy') }} as co

--- a/transform/models/intermediate/diagnostics/int_diagnostics__no_data_status.sql
+++ b/transform/models/intermediate/diagnostics/int_diagnostics__no_data_status.sql
@@ -1,0 +1,170 @@
+{{ config(
+    materialized="incremental",
+    cluster_by=["active_date"],
+    unique_key=["detector_id", "active_date"],
+    on_schema_change="sync_all_columns",
+    snowflake_warehouse=get_snowflake_refresh_warehouse(small="XL")
+) }}
+
+with
+detector_meta as (
+    select * from {{ ref('int_vds__active_detectors') }}
+    where {{ make_model_incremental('active_date') }}
+),
+
+station_meta as (
+    select * from {{ ref('int_vds__station_config') }}
+),
+
+controller_meta as (
+    select * from {{ ref('int_vds__controller_config') }}
+),
+
+equipment_meta as (
+    select
+        dm.*,
+        sm.controller_id,
+        sm.name,
+        sm.angle
+    from detector_meta as dm
+    inner join station_meta as sm
+        on
+            dm.station_id = sm.station_id
+            and {{ get_scd_2_data('dm.active_date','sm._valid_from','sm._valid_to') }}
+),
+
+equipment_all_meta as (
+    select
+        em.*,
+        cm.line_num,
+        cm.stn_address,
+        cm.controller_type
+    from equipment_meta as em
+    inner join controller_meta as cm
+        on
+            em.controller_id = cm.controller_id
+            and {{ get_scd_2_data('em.active_date','cm._valid_from','cm._valid_to') }}
+),
+
+equipment_with_samples as (
+    select
+        eam.*,
+        source.sample_ct
+    from equipment_all_meta as eam
+    left join {{ ref('int_diagnostics__samples_per_detector') }} as source
+        on
+            eam.detector_id = source.detector_id
+            and eam.active_date = source.sample_date
+),
+
+district_feed_check as (
+    select
+        ews.active_date,
+        ews.district,
+        case
+            when (count_if(ews.sample_ct > 0)) > 0 then 'Yes'
+            else 'No'
+        end as district_feed_working
+    from equipment_with_samples as ews
+    inner join {{ ref('districts') }} as d
+        on ews.district = d.district_id
+    group by ews.active_date, ews.district
+),
+
+line_feed_check as (
+    select
+        ews.active_date,
+        ews.district,
+        ews.line_num,
+        case
+            when ews.line_num is null then 'Yes'
+            when (count_if(ews.sample_ct > 0)) > 0 then 'Yes'
+            else 'No'
+        end as line_num_working
+    from equipment_with_samples as ews
+    group by ews.active_date, ews.district, ews.line_num
+),
+
+controller_feed_check as (
+    select
+        ews.active_date,
+        ews.district,
+        ews.controller_id,
+        case
+            when ews.controller_id is null then 'Yes'
+            when (count_if(ews.sample_ct > 0)) > 0 then 'Yes'
+            else 'No'
+        end as controller_feed_working
+    from equipment_with_samples as ews
+    group by ews.active_date, ews.district, ews.controller_id
+),
+
+station_feed_check as (
+    select
+        ews.active_date,
+        ews.district,
+        ews.station_id,
+        case
+            when ews.station_id is null then 'Yes'
+            when (count_if(ews.sample_ct > 0)) > 0 then 'Yes'
+            else 'No'
+        end as station_feed_working
+    from equipment_with_samples as ews
+    group by ews.active_date, ews.district, ews.station_id
+),
+
+detector_feed_check as (
+    select
+        ews.active_date,
+        ews.detector_id,
+        case
+            when ews.detector_id is null then 'Yes'
+            when (count_if(ews.sample_ct > 0)) > 0 then 'Yes'
+            else 'No'
+        end as detector_feed_working
+    from equipment_with_samples as ews
+    group by ews.active_date, ews.detector_id
+),
+
+data_feed_check as (
+    select
+        ews.active_date,
+        ews.district,
+        ews.line_num,
+        ews.controller_id,
+        ews.station_id,
+        ews.detector_id,
+        ews.sample_ct,
+        dfc.district_feed_working,
+        lfc.line_num_working,
+        cfc.controller_feed_working,
+        sfc.station_feed_working,
+        detfc.detector_feed_working
+    from equipment_with_samples as ews
+    left join district_feed_check as dfc
+        on
+            ews.active_date = dfc.active_date
+            and ews.district = dfc.district
+    left join line_feed_check as lfc
+        on
+            ews.active_date = lfc.active_date
+            and ews.district = lfc.district
+            and ews.line_num = lfc.line_num
+    left join controller_feed_check as cfc
+        on
+            ews.active_date = cfc.active_date
+            and ews.district = cfc.district
+            and ews.controller_id = cfc.controller_id
+    left join station_feed_check as sfc
+        on
+            ews.active_date = sfc.active_date
+            and ews.district = sfc.district
+            and ews.station_id = sfc.station_id
+    left join detector_feed_check as detfc
+        on
+            ews.active_date = detfc.active_date
+            and ews.detector_id = detfc.detector_id
+)
+
+select * from data_feed_check
+order by active_date, district, line_num, controller_id, station_id, detector_id


### PR DESCRIPTION
Updates were made to the detector status and 5-minute agg clearinghouse models as part of QC analysis to include stations that were missing. In the detector status model, the join was updated to include the meta data before the final CTE. The 5-minute agg clearinghouse model now uses the active detectors model to capture all active detectors on a given date.    