### PR TITLE
update incrementality of 2 intermediate models

### DIFF
--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes_with_missing_rows.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes_with_missing_rows.sql
@@ -15,6 +15,7 @@ with timestamp_spine as (
 
 detector_agg as (
     select * from {{ ref('int_clearinghouse__detector_agg_five_minutes') }}
+    -- This clause isn't strictly necessary but helps with performance on incremental builds
     where {{ make_model_incremental('sample_date') }}
 ),
 
@@ -22,14 +23,13 @@ detector_meta as (
     select * from {{ ref('int_vds__detector_config') }}
 ),
 
-/*
- * Get date range where a detector is expected to be collecting data.
- */
+/* Get date range where a detector is expected to be collecting data. */
 detector_date_range as (
     select
         detector_id,
-        active_date
+        active_date as sample_date
     from {{ ref('int_vds__active_detectors') }}
+    where {{ make_model_incremental('sample_date') }}
 ),
 
 /* Expand timestamp spine to include values per detector but only for days within the detector's date range */
@@ -38,7 +38,7 @@ spine as (
         ts.timestamp_column,
         dd.detector_id
     from timestamp_spine as ts inner join detector_date_range as dd
-        on to_date(ts.timestamp_column) = dd.active_date
+        on to_date(ts.timestamp_column) = dd.sample_date
 ),
 
 /* Join 5-minute aggregated data to the spine to get a table without missing rows */

--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes_with_missing_rows.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_agg_five_minutes_with_missing_rows.sql
@@ -7,7 +7,7 @@
 ) }}
 
 with timestamp_spine as (
-    {{ timestamp_spine(start_date="'2023-01-01'",
+    {{ timestamp_spine(start_date=var("pems_clearinghouse_start_date"),
         end_date="current_date()",
         second_increment=60*5
     ) }}

--- a/transform/models/intermediate/diagnostics/int_diagnostics__detector_status.sql
+++ b/transform/models/intermediate/diagnostics/int_diagnostics__detector_status.sql
@@ -9,11 +9,15 @@
 with
 source as (
     select * from {{ ref('int_diagnostics__samples_per_detector') }}
-    where {{ make_model_incremental('sample_date') }}
 ),
 
 detector_meta as (
     select * from {{ ref('int_vds__detector_config') }}
+),
+
+set_assgnmt as (
+    select * from {{ ref('int_diagnostics__det_diag_set_assignment') }}
+    where {{ make_model_incremental('active_date') }}
 ),
 
 assignment_with_meta as (
@@ -32,7 +36,7 @@ assignment_with_meta as (
         dm.freeway,
         dm.direction,
         dm.length
-    from {{ ref('int_diagnostics__det_diag_set_assignment') }} as set_assgnmt
+    from set_assgnmt
     inner join detector_meta as dm
         on
             set_assgnmt.station_id = dm.station_id


### PR DESCRIPTION
#408 introduced new joins to these models that affected incremental builds. More specifically, the models are generating too many rows on incremental builds, which affects performance (#414) and overwrites rows with nulls (#410).

To test these changes, I ran these models a couple times after a full refresh to verify that they don't change.

I will execute a full-refresh of these models to fix existing production data issues when this PR merges.

Fixes #410 
Fixes #414 