### PR TITLE
Ten days corridor level performance mart model bug fixing

### DIFF
--- a/transform/models/marts/performance/_performance.yml
+++ b/transform/models/marts/performance/_performance.yml
@@ -346,3 +346,70 @@ models:
           The lost Productivity perfromance metric is
           the number of lane-mile-month on the freeway lost due to operating under congested
           conditions instead of under free-flow conditions.
+  - name: performance__station_metric_agg_recent_one_week
+    description: |
+      Hourly aggregation of volume, vmt, and vht for HOV and mainline pairs for recent one week.
+      This model calculated HOV volume, vmt and vht penetration using corresponding
+      mainline station. The corresponding mainline station of HOV station was
+      determined based on proximity, and direction.
+    columns:
+      - name: TYPE
+        description: Two character string identify the VDS type.
+      - name: DISTRICT
+        description: The district in which the VDS is located. Values are 1-12.
+      - name: CITY
+        description: The city number where the VDS is located, if available.
+      - name: COUNTY
+        description: The unique number that identifies the county that contains a specific VDS within PeMS.
+      - name: DIRECTION
+        description: A string indicating the freeway direction of a specific VDS. Directions are N, E, S or W.
+      - name: FREEWAY
+        description: The freeway where the VDS is located.
+      - name: HOURLY_CATEGORY
+        description: 24-hrs have been catagorized as am peak (6-10 am),
+          am off peak (10 am to 3 pm), pm peak (3 pm to 7 pm) and
+          pm off peak (7 pm to  6am).
+      - name: HOV_NAME
+        description: Name of the HOV street.
+      - name: HOV_STATION_ID
+        description: An integer value that uniquely indentifies of a HOV station.
+      - name: HOUR_DAY
+        description: Hour of day varies from 0 to 23.
+      - name: HOV_LATITUDE
+        description: latitude of HOV station.
+      - name: HOV_LONGITUDE
+        description: longitude of HOV station.
+      - name: HOV_LENGTH_AVG
+        description: Length of HOV station.
+      - name: SAMPLE_DATE
+        description: The sample collection date.
+      - name: SAMPLE_HOUR
+        description: The sample collection hour with date.
+      - name: WEEKDAY
+        description: The day of week when the data was collected.
+      - name: WEEKDAY_STATUS
+        description: Identify weather the data was collected in weekday or weekend.
+      - name: HOV_HOURLY_AVERAGE_VHT
+        description: Hourly average HOV station vht.
+      - name: HOV_HOURLY_AVERAGE_VMT
+        description: Hourly average HOV station vmt.
+      - name: HOV_HOURLY_AVERAGE_VOLUME
+        description: Hourly average HOV station volume.
+      - name: ML_HOURLY_AVERAGE_VHT
+        description: Hourly average mainline station vht.
+      - name: ML_HOURLY_AVERAGE_VMT
+        description: Hourly average mainline station vmt.
+      - name: ML_HOURLY_AVERAGE_VOLUME
+        description: Hourly average mainline station volume.
+      - name: HOV_VHT_PENETRATION
+        description:
+          The ratio of HOV houlry average vht to mainline houlry average vht.
+          it is expressed as percentage
+      - name: HOV_VMT_PENETRATION
+        description:
+          The ratio of HOV houlry average vmt to mainline houlry average vmt.
+          it is expressed as percentage.
+      - name: HOV_VOLUME_PENETRATION
+        description:
+          The ratio of HOV houlry average volume to mainline houlry average volume.
+          it is expressed as percentage.

--- a/transform/models/marts/performance/performance__station_metric_agg_recent_one_week.sql
+++ b/transform/models/marts/performance/performance__station_metric_agg_recent_one_week.sql
@@ -1,5 +1,3 @@
-{{ config(materialized="table") }}
-
 with station_meta as (
     select * from {{ ref('int_vds__station_config') }}
 ),
@@ -130,7 +128,7 @@ station_metric_agg as (
         (sum(hov_hourly_vmt) / nullif(sum(hov_lanes), 0)) as hov_hourly_average_vmt,
         (sum(hov_hourly_vht) / nullif(sum(hov_lanes), 0)) as hov_hourly_average_vht,
         (sum(hov_hourly_volume) / nullif(sum(ml_hourly_volume), 0)) * 100 as hov_volume_penetration,
-        (sum(hov_hourly_vht) / nullif(sum(hov_hourly_vmt), 0)) * 100 as hov_vmt_penetration,
+        (sum(hov_hourly_vmt) / nullif(sum(hov_hourly_vmt), 0)) * 100 as hov_vmt_penetration,
         (sum(hov_hourly_vht) / nullif(sum(ml_hourly_vht), 0)) * 100 as hov_vht_penetration
     from station_with_ml_hov_metrics
     group by

--- a/transform/models/marts/performance/performance__station_metric_agg_recent_one_week.sql
+++ b/transform/models/marts/performance/performance__station_metric_agg_recent_one_week.sql
@@ -4,12 +4,31 @@ with station_meta as (
     select * from {{ ref('int_vds__station_config') }}
 ),
 
+county as (
+    select
+        county_id,
+        county_name
+    from {{ ref('counties') }}
+),
+
+station_with_county as (
+    -- Perform the join between station_meta and county on county_id
+    select
+        sm.* exclude (county),
+        c.county_name
+    from
+        station_meta as sm
+    inner join
+        county as c
+        on sm.county = c.county_id
+),
+
 station_pairs as (
     select
         ml.station_id as ml_station_id,
         ml.district,
         ml.city,
-        ml.county,
+        ml.county_name as county,
         ml.freeway,
         ml.direction,
         ml.absolute_postmile as ml_absolute_postmile,
@@ -25,9 +44,9 @@ station_pairs as (
         hov.physical_lanes as hov_lanes,
         abs(ml.absolute_postmile - hov.absolute_postmile) as delta_postmile
     from
-        station_meta as ml
+        station_with_county as ml
     inner join
-        station_meta as hov
+        station_with_county as hov
         on
             ml.freeway = hov.freeway
             and ml.direction = hov.direction

--- a/transform/models/marts/performance/performance__station_metric_agg_recent_one_week.sql
+++ b/transform/models/marts/performance/performance__station_metric_agg_recent_one_week.sql
@@ -59,7 +59,7 @@ hourly_station_volume as (
         hourly_vht,
         station_type
     from {{ ref('int_performance__station_metrics_agg_hourly') }}
-    where sample_date >= dateadd('day', -11, current_date())
+    where sample_date >= dateadd('day', -8, current_date())
 ),
 
 station_with_ml_hov_metrics as (
@@ -178,4 +178,7 @@ final_data_with_category as (
     from station_metric_agg
 )
 
-select * from final_data_with_category
+select
+    * exclude (sample_hour),
+    extract(hour from sample_hour) as sample_hour
+from final_data_with_category

--- a/transform/models/marts/performance/performance__station_metric_agg_recent_one_week.sql
+++ b/transform/models/marts/performance/performance__station_metric_agg_recent_one_week.sql
@@ -35,6 +35,8 @@ station_pairs as (
             and ml.station_id != hov.station_id
             and ml.station_type = 'ML'
             and hov.station_type = 'HV'
+            and ml.district != 4
+            and hov.district != 4
 ),
 
 closest_station_with_selection as (

--- a/transform/models/marts/performance/performance__station_metric_agg_recent_one_week.sql
+++ b/transform/models/marts/performance/performance__station_metric_agg_recent_one_week.sql
@@ -179,6 +179,6 @@ final_data_with_category as (
 )
 
 select
-    * exclude (sample_hour),
-    extract(hour from sample_hour) as sample_hour
+    *,
+    extract(hour from sample_hour) as hour_day
 from final_data_with_category

--- a/transform/models/marts/performance/performance__station_metric_agg_recent_ten_days.sql
+++ b/transform/models/marts/performance/performance__station_metric_agg_recent_ten_days.sql
@@ -59,7 +59,7 @@ hourly_station_volume as (
         hourly_vht,
         station_type
     from {{ ref('int_performance__station_metrics_agg_hourly') }}
-    where sample_date = dateadd('day', -11, current_date())
+    where sample_date >= dateadd('day', -8, current_date())
 ),
 
 station_with_ml_hov_metrics as (

--- a/transform/models/marts/performance/performance__station_metric_agg_recent_ten_days.sql
+++ b/transform/models/marts/performance/performance__station_metric_agg_recent_ten_days.sql
@@ -59,7 +59,7 @@ hourly_station_volume as (
         hourly_vht,
         station_type
     from {{ ref('int_performance__station_metrics_agg_hourly') }}
-    where sample_date >= dateadd('day', -8, current_date())
+    where sample_date >= dateadd('day', -11, current_date())
 ),
 
 station_with_ml_hov_metrics as (


### PR DESCRIPTION
There was bugs in logic that generate just 10 days back single day data, while our target was getting recent all 10 days data. it seems the data size is too big, I am limiting this data for just a single recent week