### PR TITLE
make clearinghouse load sooner

### DIFF
--- a/dags/load_from_clearinghouse.py
+++ b/dags/load_from_clearinghouse.py
@@ -99,14 +99,13 @@ def clearinghouse_to_s3(day: date) -> None:
 
 @task
 def pems_clearinghouse_to_s3_task(**context):
-    prev_date = (context["execution_date"] - timedelta(days=1)).date()
-    clearinghouse_to_s3(prev_date)
+    clearinghouse_to_s3(context["execution_date"].date())
 
 
 @dag(
     description="Load data from the PeMS clearinghouse webserver to S3",
     start_date=datetime(1994, 12, 1),
-    schedule_interval="0 8 * * *",  # 12 AM PST
+    schedule_interval="0 14 * * *",  # 6 AM PST
     default_args={
         "owner": "Traffic Operations",
         "depends_on_past": False,

--- a/dags/load_from_clearinghouse.py
+++ b/dags/load_from_clearinghouse.py
@@ -106,7 +106,7 @@ def pems_clearinghouse_to_s3_task(**context):
 @dag(
     description="Load data from the PeMS clearinghouse webserver to S3",
     start_date=datetime(1994, 12, 1),
-    schedule_interval="0 12 * * *",  # 4 AM PST
+    schedule_interval="0 8 * * *",  # 12 AM PST
     default_args={
         "owner": "Traffic Operations",
         "depends_on_past": False,


### PR DESCRIPTION
Fixes #455 
^mostly fixes, at least. This change puts the s3 loading 2 hours prior to our nightly build, which will decrease daily lag by 1 day. Specifically, lag will go from 3 to 2 days. To get us to 1 day, we would need to load data as soon as it becomes available in clearinghouse.

Currently, "yesterday's" data arrives during the hours of 4:00 to 5:30 AM the next day. To schedule the current process of loading to s3, we would want to start it ~6-7 to be safe. This would lead to kicking off the nightly build around 7-8 AM, which is arguably too late to guarantee data availability before people start work, some days, at least. I think it's worth it to keep the current implementation, especially considering that the data relay server should improve this latency in the future.

@mmmiah fyi

