### PR TITLE
change unique keys from 'station_id' + 'lane' to 'detector_id'

### DIFF
--- a/transform/models/intermediate/diagnostics/int_diagnostics__samples_per_detector.sql
+++ b/transform/models/intermediate/diagnostics/int_diagnostics__samples_per_detector.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized="incremental",
     cluster_by=['sample_date'],
-    unique_key=['station_id', 'sample_date', 'lane'],
+    unique_key=['detector_id', 'sample_date'],
     on_schema_change='sync_all_columns',
     snowflake_warehouse=get_snowflake_refresh_warehouse(small="XL")
 ) }}

--- a/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes.sql
+++ b/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes.sql
@@ -2,7 +2,7 @@
         materialized='incremental',
         on_schema_change="append_new_columns",
         cluster_by=["sample_date"],
-        unique_key=["station_id", "lane", "sample_timestamp", "sample_date"],
+        unique_key=["detector_id", "sample_timestamp", "sample_date"],
         snowflake_warehouse = get_snowflake_refresh_warehouse(big="XL", small="XS"),
     )
 }}

--- a/transform/models/intermediate/imputation/int_imputation__detector_imputed_agg_five_minutes.sql
+++ b/transform/models/intermediate/imputation/int_imputation__detector_imputed_agg_five_minutes.sql
@@ -2,7 +2,7 @@
         materialized='incremental',
         on_schema_change="append_new_columns",
         cluster_by=["sample_date"],
-        unique_key=["station_id", "lane", "sample_timestamp", "sample_date"],
+        unique_key=["detector_id", "sample_timestamp", "sample_date"],
         snowflake_warehouse = get_snowflake_refresh_warehouse(big="XL", small="XS"),
     )
 }}


### PR DESCRIPTION
Three models in the Caltrans project now inherit the detector_id column, making the surrogate unique key for detector (station_id + lane) no longer necessary / useful. 