### PR TITLE
change unique key to detector_id for constant occupancy model

### DIFF
--- a/transform/models/intermediate/diagnostics/_diagnostics.yml
+++ b/transform/models/intermediate/diagnostics/_diagnostics.yml
@@ -178,7 +178,7 @@ models:
       value of that delta and sums that over a window of 48 rows which equates
       to 4 hours (5 min data x 12 = 60 (one hour) then 12 x 4 = 48 which is 4
       hours) where occupancy is not null and not zero. Finally it outputs the
-      minimum value grouped by id, lane, sample_date.
+      minimum value grouped by detector_id and sample_date.
     columns:
       - name: min_occupancy_delta
         description: |

--- a/transform/models/intermediate/diagnostics/int_diagnostics__constant_occupancy.sql
+++ b/transform/models/intermediate/diagnostics/int_diagnostics__constant_occupancy.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized="incremental",
     cluster_by=['sample_date'],
-    unique_key=['station_id', 'lane', 'sample_date'],
+    unique_key=['detector_id', 'sample_date'],
     snowflake_warehouse=get_snowflake_refresh_warehouse(small="XL")
 ) }}
 
@@ -19,14 +19,13 @@ source as (
 
 calculate_occupancy_delta as (
     select
-        station_id,
+        detector_id,
         sample_timestamp,
         sample_date,
-        lane,
         occupancy_avg,
         occupancy_avg
         - LAG(occupancy_avg)
-            over (partition by station_id, lane, sample_date order by sample_timestamp)
+            over (partition by detector_id, sample_date order by sample_timestamp)
             as occupancy_delta
     from source
 ),
@@ -39,7 +38,7 @@ sum_occupancy_delta as (
         /* we are looking at a window of 48 rows because that is a 4 hour window
         (5 min data * 12 = 60 (one hour) then 12 * 4 = 48 which is 4 hours) */
             over (
-                partition by station_id, lane, sample_date
+                partition by detector_id, sample_date
                 order by sample_timestamp rows between 47 preceding and current row
             )
             as abs_val_occupancy_delta_summed
@@ -47,17 +46,16 @@ sum_occupancy_delta as (
     qualify
         (occupancy_avg != 0 or occupancy_avg is not null)
         and ROW_NUMBER() over (
-            partition by station_id, lane, sample_date
+            partition by detector_id, sample_date
             order by sample_timestamp
         ) >= 48
 
 )
 
 select
-    station_id,
+    detector_id,
     sample_date,
-    lane,
     MIN(abs_val_occupancy_delta_summed) as min_occupancy_delta
 from sum_occupancy_delta
-group by station_id, lane, sample_date
+group by detector_id, sample_date
 order by sample_date

--- a/transform/models/intermediate/diagnostics/int_diagnostics__detector_status.sql
+++ b/transform/models/intermediate/diagnostics/int_diagnostics__detector_status.sql
@@ -133,8 +133,7 @@ detector_status as (
 
     left join {{ ref('int_diagnostics__constant_occupancy') }} as co
         on
-            awm.station_id = co.station_id
-            and sps.lane = co.lane
+            awm.detector_id = co.detector_id
             and awm.active_date = co.sample_date
 
     left join {{ ref('int_diagnostics__no_data_status') }} as nds


### PR DESCRIPTION
trying this again! same code changes as PR #471 , but this time I'll run the full-refresh of constant occupancy and its downstream models in production after the code is merged so that the nightly build doesn't fail. :) 