### PR TITLE
adding new versionless flags

### DIFF
--- a/transform/dbt_project.yml
+++ b/transform/dbt_project.yml
@@ -7,6 +7,10 @@ flags:
   send_anonymous_usage_stats: false
   use_colors: true
   warn_error: false
+  state_modified_compare_more_unrendered_values: true
+  skip_nodes_if_on_run_start_fails: true
+  require_explicit_package_overrides_for_builtin_materializations: true
+  source_freshness_run_project_hooks: false
 
 # This setting configures which "profile" dbt uses for this project.
 profile: caltrans_pems


### PR DESCRIPTION
Similar to the work done in the Caldata dbt project -- this explicitly configures the new flags in dbt Versionless that we care about turning either on or off for the Caltrans project:

`state_modified_compare_more_unrendered_values: true `- adding this flag and setting it to true, then running a full refresh, will hopefully improve CI when we do this in the Caltrans project

`skip_nodes_if_on_run_start_fails: true `- unsure if we want this flag as true or false. if true, it will skip running anything if any of the on_run_start hooks fails.

`require_explicit_package_overrides_for_builtin_materializations: true `- this seems like a no-brainer extra security layer that we might as well turn on sooner rather than later. more details here if interested: [GHSA-p3f3-5ccg-83xq](https://github.com/dbt-labs/dbt-core/security/advisories/GHSA-p3f3-5ccg-83xq)

`source_freshness_run_project_hooks: false` - we do not want to / need to check source freshness for our project hooks  https://docs.getdbt.com/reference/global-configs/behavior-changes#project-hooks-with-source-freshness


More info on these flags can be found in the dbt documentation here: https://docs.getdbt.com/reference/global-configs/behavior-changes#behavior-change-flags