### PR TITLE
Summer versionless test

### DIFF
--- a/transform/models/intermediate/performance/int_performance__station_aadt_with_K_value.sql
+++ b/transform/models/intermediate/performance/int_performance__station_aadt_with_K_value.sql
@@ -480,5 +480,6 @@ select distinct
     aadt_8,
     k_30,
     k_50,
-    k_100
+    k_100,
+    1 as test
 from aadt_1_8_kfactors

--- a/transform/models/intermediate/performance/int_performance__station_aadt_with_K_value.sql
+++ b/transform/models/intermediate/performance/int_performance__station_aadt_with_K_value.sql
@@ -481,5 +481,5 @@ select distinct
     k_30,
     k_50,
     k_100,
-    1 as test
+    2 as test
 from aadt_1_8_kfactors


### PR DESCRIPTION
Testing the CI job timing with the same change, now that the prod environment is working in Versionless and we've had a successful Nightly build. 

The hope here is that there is a noticeable difference in CI timing from the test I ran yesterday, and (more importantly, since timing might have been affected by the missing data from the detector source tables yesterday) that the logs show that CI is not rebuilding incremental models that had no changes made to them in this PR. 