### PR TITLE
Detector Status and Set Assignment Updates

### DIFF
--- a/transform/models/intermediate/diagnostics/int_diagnostics__det_diag_set_assignment.sql
+++ b/transform/models/intermediate/diagnostics/int_diagnostics__det_diag_set_assignment.sql
@@ -13,23 +13,19 @@ station_diagnostic_set_assign as (
         station_id,
         district,
         station_type,
+        dt_set_id,
         _valid_from as station_valid_from,
         _valid_to as station_valid_to,
         case
-            /*when LIKE(UPPER(THRESHOLD_SET), "LOW%") then "Low_Volume"
-            This value is currently in district config file but not in
-            our current metadata files
-            when LIKE(UPPER(THRESHOLD_SET), "RURAL%") then "Rural"
-            We need the definition of when a station is considered
-            Rural from Iteris
-            */
-            when district = 11 then 'Urban_D11'
-            when district = 6 then 'D6_Ramps'
+            when UPPER(dt_set_id) like 'LOW%' then 'Low_Volume'
+            when UPPER(dt_set_id) like 'RURAL%' then 'Rural'
+            when UPPER(dt_set_id) like 'URBAN_D11%' then 'Urban_D11'
+            when UPPER(dt_set_id) like 'D6_RAMPS%' then 'D6_Ramps'
             else 'Urban'
         end as station_diagnostic_set_id,
         case
-            when station_type in ('FR', 'OR') then 'ramp'
-            else 'mainline'
+            when station_type in ('ML', 'HV') then 'mainline'
+            else 'ramp'
         end as station_diagnostic_method_id
 
     from {{ ref ('int_vds__active_stations') }}

--- a/transform/models/intermediate/diagnostics/int_diagnostics__detector_status.sql
+++ b/transform/models/intermediate/diagnostics/int_diagnostics__detector_status.sql
@@ -86,33 +86,39 @@ detector_status as (
                 then 'Insufficient Data'
             when
                 awm.station_diagnostic_method_id = 'ramp'
-                and sps.zero_vol_ct / ({{ var("detector_status_max_sample_value") }})
-                > (awm.zero_flow_percent / 100)
+                and
+                (sps.zero_vol_ct / sps.sample_ct)
+                >= (awm.zero_flow_percent / 100)
                 then 'Card Off'
             when
                 awm.station_diagnostic_method_id = 'mainline'
-                and sps.zero_occ_ct / ({{ var("detector_status_max_sample_value") }})
-                > (awm.zero_occupancy_percent / 100)
+                and
+                (sps.zero_occ_ct / sps.sample_ct)
+                >= (awm.zero_occupancy_percent / 100)
                 then 'Card Off'
             when
                 awm.station_diagnostic_method_id = 'ramp'
-                and sps.high_volume_ct / ({{ var("detector_status_max_sample_value") }})
-                > (awm.high_flow_percent / 100)
+                and
+                (sps.high_volume_ct / sps.sample_ct)
+                >= (awm.high_flow_percent / 100)
                 then 'High Val'
             when
                 awm.station_diagnostic_method_id = 'mainline'
-                and sps.high_occupancy_ct / ({{ var("detector_status_max_sample_value") }})
-                > (awm.high_occupancy_percent / 100)
+                and
+                (sps.high_occupancy_ct / sps.sample_ct)
+                >= (awm.high_occupancy_percent / 100)
                 then 'High Val'
             when
                 awm.station_diagnostic_method_id = 'mainline'
-                and sps.zero_vol_pos_occ_ct / ({{ var("detector_status_max_sample_value") }})
-                > (awm.flow_occupancy_percent / 100)
+                and
+                (sps.zero_vol_pos_occ_ct / sps.sample_ct)
+                >= (awm.flow_occupancy_percent / 100)
                 then 'Intermittent'
             when
                 awm.station_diagnostic_method_id = 'mainline'
-                and sps.zero_occ_pos_vol_ct / ({{ var("detector_status_max_sample_value") }})
-                > (awm.occupancy_flow_percent / 100)
+                and
+                (sps.zero_occ_pos_vol_ct / sps.sample_ct)
+                >= (awm.occupancy_flow_percent / 100)
                 then 'Intermittent'
             when
                 coalesce(co.min_occupancy_delta = 0, false)


### PR DESCRIPTION
This PR updates the set assignment model to associate ML and HV stations to mainline threshold values and all other station types to the ramp threshold values. This also accounts for manual threshold set values captured in the station_log model that contain user selected changes to the threshold set assignments.

In the detector status model, we are now comparing counted values for various diagnostic tests against actual sample counts.

Based on my QC work, there are a few inconsistencies with the Constant value for some stations and we do not have the complete logic for the existing Feed Unstable status, but all other statuses appear consistent between the existing system and this project. 
This fixes #398