### PR TITLE
Update Models with gfactor Speed

### DIFF
--- a/transform/models/intermediate/clearinghouse/_clearinghouse.yml
+++ b/transform/models/intermediate/clearinghouse/_clearinghouse.yml
@@ -226,6 +226,7 @@ models:
     tests:
       - five_minute_daily_count:
           group_by_columns: ["detector_id", "sample_date"]
+    columns:
       - name: speed_weighted
         description: |
           If the detector reports a measured speed (miles/hour) in the lane then that value will be used.

--- a/transform/models/intermediate/clearinghouse/_clearinghouse.yml
+++ b/transform/models/intermediate/clearinghouse/_clearinghouse.yml
@@ -226,6 +226,14 @@ models:
     tests:
       - five_minute_daily_count:
           group_by_columns: ["detector_id", "sample_date"]
+      - name: speed_weighted
+        description: |
+          If the detector reports a measured speed (miles/hour) in the lane then that value will be used.
+          The reported value is weighted by the number of vehicles in each sample period. If no speed is
+          reported by the device than the speed value calculated from the
+          int_clearinghouse__detector_g_factor_based_speed model will be placed in the corresponding
+          detector and timestamp row. If there is no device or g-factor provided speed the value will remain
+          null and be populated using imputation in downstream models.
   - name: int_clearinghouse__detector_g_factor_based_speed
     description: |
       This model calculates the g-factor based smoothing speed. According to the PeMS documentation, the

--- a/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_g_factor_based_speed.sql
+++ b/transform/models/intermediate/clearinghouse/int_clearinghouse__detector_g_factor_based_speed.sql
@@ -20,7 +20,7 @@ detector_agg as (
         occupancy_avg,
         speed_weighted,
         volume_observed
-    from {{ ref('int_clearinghouse__detector_agg_five_minutes_with_missing_rows') }}
+    from {{ ref('int_clearinghouse__detector_agg_five_minutes') }}
     where {{ make_model_incremental('sample_date') }}
 ),
 

--- a/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes.sql
+++ b/transform/models/intermediate/imputation/int_imputation__detector_agg_five_minutes.sql
@@ -88,8 +88,7 @@ unimputed as (
         -- If the detector_id in the join is not null, it means that the detector
         -- is considered to be "good" for a given date.
         (good_detectors.detector_id is not null) as detector_is_good,
-        coalesce(base.speed_weighted, (base.volume_sum * 22) / nullifzero(base.occupancy_avg) * (1 / 5280) * 12)
-            as speed_five_mins
+        base.speed_weighted as speed_five_mins
     from base
     left join good_detectors
         on

--- a/transform/models/intermediate/performance/int_performance__detector_metrics_agg_five_minutes.sql
+++ b/transform/models/intermediate/performance/int_performance__detector_metrics_agg_five_minutes.sql
@@ -38,17 +38,6 @@ five_minute_agg as (
 aggregated_speed as (
     select
         *,
-        --A preliminary speed calcuation was developed on 3/22/24
-        --using a vehicle effective length of 22 feet
-        --(16 ft vehicle + 6 ft detector zone) feet and using
-        --a conversion to get miles per hour (5280 ft / mile and 12
-        --5-minute intervals in an hour).
-        --The following code may be used if we want to use speed from raw data
-        --coalesce(speed_raw, ((volume * 22) / nullifzero(occupancy)
-        --* (1 / 5280) * 12))
-        --impute five minutes missing speed
-        coalesce(speed_weighted, (volume_sum * 22) / nullifzero(occupancy_avg) * (1 / 5280) * 12)
-            as speed_five_mins,
         -- create a boolean function to track wheather speed is imputed or not
         coalesce(speed_five_mins != speed_weighted or (speed_five_mins is not null and speed_weighted is null), false)
         -- coalesce(speed_weighted is null, false)

--- a/transform/models/intermediate/performance/int_performance__detector_metrics_agg_five_minutes.sql
+++ b/transform/models/intermediate/performance/int_performance__detector_metrics_agg_five_minutes.sql
@@ -23,7 +23,7 @@ five_minute_agg as (
         sample_ct,
         volume_sum,
         occupancy_avg,
-        speed_five_mins as speed_weighted,
+        speed_five_mins,
         station_type,
         absolute_postmile,
         volume_imputation_method,
@@ -33,16 +33,6 @@ five_minute_agg as (
         station_valid_to
     from {{ ref('int_imputation__detector_imputed_agg_five_minutes') }}
     where {{ make_model_incremental('sample_date') }}
-),
-
-aggregated_speed as (
-    select
-        *,
-        -- create a boolean function to track wheather speed is imputed or not
-        coalesce(speed_five_mins != speed_weighted or (speed_five_mins is not null and speed_weighted is null), false)
-        -- coalesce(speed_weighted is null, false)
-            as is_speed_calculated
-    from five_minute_agg
 ),
 
 vmt_vht_metrics as (
@@ -56,7 +46,7 @@ vmt_vht_metrics as (
         vmt / nullifzero(vht) as q_value,
         -- travel time
         60 / nullifzero(q_value) as tti
-    from aggregated_speed
+    from five_minute_agg
 ),
 
 delay_metrics as (


### PR DESCRIPTION
This PR makes the following changes:

- Update the detector_agg reference in the g-factor model from the int_clearinghouse__detector_agg_five_minutes_with_missing_rows to int_clearinghouse__detector_agg_five_minutes model
- In the int_clearinghouse__detector_agg_five_minutes_with_missing_rows model I added the g-factor speed data to detectors/timestamps where speed is not being provided by the field devices
- In the int_imputation__detector_agg_five_minutes and int_performance__detector_metrics_agg_five_minutes models remove the old speed calculation formula and notes
- YAML file updated describing the speed value being used in the int_clearinghouse__detector_agg_five_minutes_with_missing_rows model.

Resolves #484 