### PR TITLE
disable poetry package mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "\"Traffic Operations PeMS Modernization\""
 authors = ["Traffic Operations <Zhenyu.Zhu@dot.ca.gov>"]
 license = "MIT"
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "~3.10"


### PR DESCRIPTION
It looks like poetry 2.0 is out and our pre-commit workflow (at a minimum) is broken. I think the clearest solution is to call out, explicitly, that we're using poetry for dependency management only.