### PR TITLE
Add Copy History tests to db96 Sources

### DIFF
--- a/transform/models/_sources.yml
+++ b/transform/models/_sources.yml
@@ -282,6 +282,7 @@ sources:
           for an onramp.
         data_tests:
           - not_empty
+          - copy_history_24h
           - unique:
               column_name: controller_id
         columns:
@@ -311,6 +312,7 @@ sources:
               combination_of_columns:
                 - controller_id
                 - time_id
+          - copy_history_24h
         freshness:
           warn_after:
             count: 30
@@ -351,6 +353,7 @@ sources:
           Metadata for a single VDS station. Multiple stations may be connected to
           a single controller, and multiple detectors may be connected to a single station.
         data_tests:
+          - copy_history_24h
           - not_empty
           - unique:
               column_name: station_id
@@ -376,6 +379,7 @@ sources:
           A log table showing updates to the station config. This can be joined
           with the `station_config` table to get a full history of station metadata.
         data_tests:
+          - copy_history_24h
           - not_empty
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns:
@@ -428,6 +432,7 @@ sources:
           Multiple detectors across a set of lanes constitute a station.
         data_tests:
           - not_empty
+          - copy_history_24h
           - unique:
               column_name: detector_id
         columns:
@@ -443,6 +448,7 @@ sources:
           with the `detector_config` table to get a full history of detector metadata.
         data_tests:
           - not_empty
+          - copy_history_24h
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns:
                 - detector_id

--- a/transform/tests/generic/copy_history_24h.sql
+++ b/transform/tests/generic/copy_history_24h.sql
@@ -1,0 +1,25 @@
+{% test copy_history_24h(model) %}
+
+/* This grabs the model's available copy history (past 14 days) from Snowflake
+see: https://docs.snowflake.com/en/sql-reference/functions/copy_history
+*/
+with validation as (
+   select LAST_LOAD_TIME
+   from table(
+    INFORMATION_SCHEMA.COPY_HISTORY(
+        table_name => '{{ model }}',
+        start_time=> DATEADD(days, -14, CURRENT_TIMESTAMP())
+        )
+    )
+),
+
+-- This checks if the last recorded load time was more than 24 hours ago
+validation_errors as (
+   select LAST_LOAD_TIME
+   from validation
+   where LAST_LOAD_TIME < DATEADD(days, -1, CURRENT_TIMESTAMP())
+)
+
+select * from validation_errors
+
+{% endtest %}


### PR DESCRIPTION
Created a generic test to check if last load time in Snowflake Copy History for a given model is within the last 24 hours.

Applied that test to these source tables:

```
    CONTROLLER_CONFIG
    CONTROLLER_CONFIG_LOG
    DETECTOR_CONFIG
    DETECTOR_CONFIG_LOG
    STATION_CONFIG
    STATION_CONFIG_LOG
```
