### PR TITLE
Include column names in parquet unloading

### DIFF
--- a/transform/macros/unload_relation.sql
+++ b/transform/macros/unload_relation.sql
@@ -17,6 +17,7 @@
           partition by {{ partitioning }}
       {% endif %}
       file_format = (type=parquet)
+      header = true
       {% if partitioning %}
           max_file_size = 134217728 -- 128 MiB
       {% else %}


### PR DESCRIPTION
Fixes #527, thanks for raising the issue @ZhenyuZhu-Caltrans and @thehanggit .

Once merged, the marts should be updated after the next nightly run