### PR TITLE
Add active days column

### DIFF
--- a/transform/models/marts/performance/performance__station_bottleneck_agg_monthly.sql
+++ b/transform/models/marts/performance/performance__station_bottleneck_agg_monthly.sql
@@ -10,6 +10,7 @@ with monthly_bottleneck as (
         freeway,
         direction,
         absolute_postmile,
+        monthly_active_days,
         monthly_time_shift_duration,
         monthly_time_shift_extent,
         county


### PR DESCRIPTION
For the monthly bottleneck table, I forgot to add a "monthly active days" column and therefore fixed it.