### PR TITLE
clean data table by appropriate partition

### DIFF
--- a/transform/models/marts/performance/performance__station_metrics_agg_daily_city.sql
+++ b/transform/models/marts/performance/performance__station_metrics_agg_daily_city.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized="table",
-    unload_partitioning="('year=' || to_varchar(date_part(year, sample_date)) || '/month=' || to_varchar(date_part(month, sample_date)))",
-) }}
-
 with station_daily_data as (
     select *
     from {{ ref('int_performance__station_metrics_agg_daily') }}

--- a/transform/models/marts/performance/performance__station_metrics_agg_daily_county.sql
+++ b/transform/models/marts/performance/performance__station_metrics_agg_daily_county.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized="table",
-    unload_partitioning="('year=' || to_varchar(date_part(year, sample_date)) || '/month=' || to_varchar(date_part(month, sample_date)))",
-) }}
-
 with station_daily_data as (
     select *
     from {{ ref('int_performance__station_metrics_agg_daily') }}

--- a/transform/models/marts/performance/performance__station_metrics_agg_daily_district.sql
+++ b/transform/models/marts/performance/performance__station_metrics_agg_daily_district.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized="table",
-    unload_partitioning="('year=' || to_varchar(date_part(year, sample_date)) || '/month=' || to_varchar(date_part(month, sample_date)))",
-) }}
-
 with station_daily_data as (
     select *
     from {{ ref('int_performance__station_metrics_agg_daily') }}

--- a/transform/models/marts/performance/performance__station_metrics_agg_weekly.sql
+++ b/transform/models/marts/performance/performance__station_metrics_agg_weekly.sql
@@ -1,3 +1,8 @@
+{{ config(
+    materialized="table",
+    unload_partitioning="('year=' || to_varchar(date_part(year, sample_week_start_date)))",
+) }}
+
 with weekly as (
     select
         station_id,

--- a/transform/models/marts/performance/performance__station_metrics_unpivot_agg_daily_city.sql
+++ b/transform/models/marts/performance/performance__station_metrics_unpivot_agg_daily_city.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized="table",
-    unload_partitioning="('year=' || to_varchar(date_part(year, sample_date)) || '/month=' || to_varchar(date_part(month, sample_date)))",
-) }}
-
 -- read the volume, occupancy and speed daily level data
 with station_daily_data as (
     select *

--- a/transform/models/marts/performance/performance__station_metrics_unpivot_agg_daily_county.sql
+++ b/transform/models/marts/performance/performance__station_metrics_unpivot_agg_daily_county.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized="table",
-    unload_partitioning="('year=' || to_varchar(date_part(year, sample_date)) || '/month=' || to_varchar(date_part(month, sample_date)))",
-) }}
-
 -- read the volume, occupancy and speed daily level data
 with station_daily_data as (
     select *

--- a/transform/models/marts/performance/performance__station_metrics_unpivot_agg_daily_district.sql
+++ b/transform/models/marts/performance/performance__station_metrics_unpivot_agg_daily_district.sql
@@ -1,8 +1,3 @@
-{{ config(
-    materialized="table",
-    unload_partitioning="('year=' || to_varchar(date_part(year, sample_date)) || '/month=' || to_varchar(date_part(month, sample_date)))",
-) }}
-
 -- read the volume, occupancy and speed daily level data
 with station_daily_data as (
     select *

--- a/transform/models/marts/performance/performance__station_metrics_unpivot_agg_weekly.sql
+++ b/transform/models/marts/performance/performance__station_metrics_unpivot_agg_weekly.sql
@@ -1,3 +1,8 @@
+{{ config(
+    materialized="table",
+    unload_partitioning="('year=' || to_varchar(date_part(year, sample_week_start_date)))",
+) }}
+
 with weekly as (
     select * from {{ ref('int_performance__station_metrics_agg_weekly') }}
 ),


### PR DESCRIPTION
This is related to #550.

The goal here is to partition every table in marts/performance to ensure that the sizes of them are limited to 20-30 MB. Typically, we use temporal segmentation: 'year', 'month', etc.