### PR TITLE
Add names and abbreviations to city and county

### DIFF
--- a/transform/models/marts/diagnostics/_diagnostics.yml
+++ b/transform/models/marts/diagnostics/_diagnostics.yml
@@ -34,7 +34,7 @@ models:
       - name: city_name
         description: The real city name that contains a specific VDS within PeMS.
       - name: city_abb
-        description: The city name's abbreviation that contains a specific VDS within PeMS.      
+        description: The city name's abbreviation that contains a specific VDS within PeMS.
       - name: freeway
         description: The freeway on which the station is installed.
       - name: direction
@@ -111,7 +111,7 @@ models:
       - name: city_name
         description: The real city name that contains a specific VDS within PeMS.
       - name: city_abb
-        description: The city name's abbreviation that contains a specific VDS within PeMS.      
+        description: The city name's abbreviation that contains a specific VDS within PeMS.
       - name: freeway
         description: The freeway on which the station is installed.
       - name: direction
@@ -175,7 +175,7 @@ models:
       - name: city_name
         description: The real city name that contains a specific VDS within PeMS.
       - name: city_abb
-        description: The city name's abbreviation that contains a specific VDS within PeMS.      
+        description: The city name's abbreviation that contains a specific VDS within PeMS.
       - name: freeway
         description: The freeway on which the station is installed.
       - name: direction

--- a/transform/models/marts/diagnostics/_diagnostics.yml
+++ b/transform/models/marts/diagnostics/_diagnostics.yml
@@ -25,8 +25,16 @@ models:
         description: The Caltrans district for the station.
       - name: county
         description: The county FIPS code in which the station installed.
+      - name: county_name
+        description: The real county name that contains a specific VDS within PeMS.
+      - name: county_abb
+        description: The county name's abbreviation that contains a specific VDS within PeMS.
       - name: city
         description: The city FIPS code in which the station is installed.
+      - name: city_name
+        description: The real city name that contains a specific VDS within PeMS.
+      - name: city_abb
+        description: The city name's abbreviation that contains a specific VDS within PeMS.      
       - name: freeway
         description: The freeway on which the station is installed.
       - name: direction
@@ -94,8 +102,16 @@ models:
         description: The Caltrans district for the station.
       - name: county
         description: The county FIPS code in which the station installed.
+      - name: county_name
+        description: The real county name that contains a specific VDS within PeMS.
+      - name: county_abb
+        description: The county name's abbreviation that contains a specific VDS within PeMS.
       - name: city
         description: The city FIPS code in which the station is installed.
+      - name: city_name
+        description: The real city name that contains a specific VDS within PeMS.
+      - name: city_abb
+        description: The city name's abbreviation that contains a specific VDS within PeMS.      
       - name: freeway
         description: The freeway on which the station is installed.
       - name: direction
@@ -149,10 +165,17 @@ models:
       - name: district
         description: The Caltrans district for the station.
       - name: county
-        description: The county FIPS code in which the station is installed.
-
+        description: The county FIPS code in which the station installed.
+      - name: county_name
+        description: The real county name that contains a specific VDS within PeMS.
+      - name: county_abb
+        description: The county name's abbreviation that contains a specific VDS within PeMS.
       - name: city
         description: The city FIPS code in which the station is installed.
+      - name: city_name
+        description: The real city name that contains a specific VDS within PeMS.
+      - name: city_abb
+        description: The city name's abbreviation that contains a specific VDS within PeMS.      
       - name: freeway
         description: The freeway on which the station is installed.
       - name: direction

--- a/transform/models/marts/diagnostics/diagnostics__detector_daily_by_station.sql
+++ b/transform/models/marts/diagnostics/diagnostics__detector_daily_by_station.sql
@@ -80,6 +80,10 @@ detector_status_by_station_with_metadata as (
 
 detector_status_by_station_with_metadatac as (
     {{ get_county_name('detector_status_by_station_with_metadata') }}
+),
+
+detector_status_by_station_with_metadatacc as (
+    {{ get_city_name('detector_status_by_station_with_metadatac') }}
 )
 
-select * from detector_status_by_station_with_metadatac
+select * from detector_status_by_station_with_metadatacc

--- a/transform/models/marts/diagnostics/diagnostics__detector_daily_detail.sql
+++ b/transform/models/marts/diagnostics/diagnostics__detector_daily_detail.sql
@@ -12,6 +12,10 @@ detector_status as (
 
 detector_statusc as (
     {{ get_county_name('detector_status') }}
+),
+
+detector_statuscc as (
+    {{ get_city_name('detector_statusc') }}
 )
 
-select * from detector_statusc
+select * from detector_statuscc

--- a/transform/models/marts/diagnostics/diagnostics__detector_monthly_by_station.sql
+++ b/transform/models/marts/diagnostics/diagnostics__detector_monthly_by_station.sql
@@ -15,19 +15,18 @@ detector_monthly_status_by_station as (
     select
         sample_month,
         station_id,
-        county,
-        county_name,
-        county_abb,
-        city,
-        city_name,
-        city_abb
+        MAX(case when rn = 1 then county end) as county,
+        MAX(case when rn = 1 then county_name end) as county_name,
+        MAX(case when rn = 1 then county_abb end) as county_abb,
+        MAX(case when rn = 1 then city end) as city,
+        MAX(case when rn = 1 then city_name end) as city_name,
+        MAX(case when rn = 1 then city_abb end) as city_abb,
         MAX(case when rn = 1 then district end) as district,
         MAX(case when rn = 1 then state_postmile end) as state_postmile,
         MAX(case when rn = 1 then absolute_postmile end) as absolute_postmile,
         MAX(case when rn = 1 then latitude end) as latitude,
         MAX(case when rn = 1 then longitude end) as longitude,
         MAX(case when rn = 1 then station_type end) as station_type,
-        MAX(case when rn = 1 then city end) as city,
         MAX(case when rn = 1 then freeway end) as freeway,
         MAX(case when rn = 1 then direction end) as direction,
         SUM(detector_count) as monthly_detector_count,
@@ -43,13 +42,7 @@ detector_monthly_status_by_station as (
         detector_daily_status
     group by
         station_id,
-        sample_month,
-        county,
-        county_name,
-        county_abb,
-        city,
-        city_name,
-        city_abb
+        sample_month
 )
 
 select * from detector_monthly_status_by_station

--- a/transform/models/marts/diagnostics/diagnostics__detector_monthly_by_station.sql
+++ b/transform/models/marts/diagnostics/diagnostics__detector_monthly_by_station.sql
@@ -16,6 +16,8 @@ detector_monthly_status_by_station as (
         sample_month,
         station_id,
         county,
+        county_name,
+        county_abb,
         MAX(case when rn = 1 then district end) as district,
         MAX(case when rn = 1 then state_postmile end) as state_postmile,
         MAX(case when rn = 1 then absolute_postmile end) as absolute_postmile,

--- a/transform/models/marts/diagnostics/diagnostics__detector_monthly_by_station.sql
+++ b/transform/models/marts/diagnostics/diagnostics__detector_monthly_by_station.sql
@@ -18,6 +18,9 @@ detector_monthly_status_by_station as (
         county,
         county_name,
         county_abb,
+        city,
+        city_name,
+        city_abb
         MAX(case when rn = 1 then district end) as district,
         MAX(case when rn = 1 then state_postmile end) as state_postmile,
         MAX(case when rn = 1 then absolute_postmile end) as absolute_postmile,
@@ -41,7 +44,12 @@ detector_monthly_status_by_station as (
     group by
         station_id,
         sample_month,
-        county
+        county,
+        county_name,
+        county_abb,
+        city,
+        city_name,
+        city_abb
 )
 
 select * from detector_monthly_status_by_station

--- a/transform/models/marts/geo/geo__current_detectors.sql
+++ b/transform/models/marts/geo/geo__current_detectors.sql
@@ -12,6 +12,10 @@ current_detectors as (
 
 current_detectorsc as (
     {{ get_county_name('current_detectors') }}
+),
+
+current_detectorscc as (
+    {{ get_city_name('current_detectorsc') }}
 )
 
-select * from current_detectorsc
+select * from current_detectorscc

--- a/transform/models/marts/geo/geo__current_stations.sql
+++ b/transform/models/marts/geo/geo__current_stations.sql
@@ -12,6 +12,10 @@ current_stations as (
 
 current_stationsc as (
     {{ get_county_name('current_stations') }}
+),
+
+current_stationscc as (
+    {{ get_city_name('current_stationsc') }}
 )
 
-select * from current_stationsc
+select * from current_stationscc

--- a/transform/models/marts/imputation/_imputation.yml
+++ b/transform/models/marts/imputation/_imputation.yml
@@ -103,7 +103,7 @@ models:
       - name: CITY_NAME
         description: The real city name that contains a specific VDS within PeMS.
       - name: CITY_ABB
-        description: The city name's abbreviation that contains a specific VDS within PeMS.      
+        description: The city name's abbreviation that contains a specific VDS within PeMS.
       - name: SAMPLE_DATE
         description: The date on which the sample was taken.
       - name: SAMPLE_TIMESTAMP

--- a/transform/models/marts/imputation/_imputation.yml
+++ b/transform/models/marts/imputation/_imputation.yml
@@ -94,6 +94,16 @@ models:
           - not_null
       - name: STATION_ID
         description: The station ID.
+      - name: COUNTY_NAME
+        description: The real county name that contains a specific VDS within PeMS.
+      - name: COUNTY_ABB
+        description: The county name's abbreviation that contains a specific VDS within PeMS.
+      - name: CITY
+        description: The city FIPS code in which the station is installed.
+      - name: CITY_NAME
+        description: The real city name that contains a specific VDS within PeMS.
+      - name: CITY_ABB
+        description: The city name's abbreviation that contains a specific VDS within PeMS.      
       - name: SAMPLE_DATE
         description: The date on which the sample was taken.
       - name: SAMPLE_TIMESTAMP

--- a/transform/models/marts/imputation/imputation__detector_imputed_agg_five_minutes.sql
+++ b/transform/models/marts/imputation/imputation__detector_imputed_agg_five_minutes.sql
@@ -14,6 +14,10 @@ with imputation_five_mins as (
 
 imputation_five_minsc as (
     {{ get_county_name('imputation_five_mins') }}
+),
+
+imputation_five_minscc as (
+    {{ get_city_name('imputation_five_minsc') }}
 )
 
-select * from imputation_five_minsc
+select * from imputation_five_minscc


### PR DESCRIPTION
Per Zhenyu's request, this PR aims to add additional information for tables in marts. Specifically, we need to contain county, county name, county abb, city, city name, and city abb. In the performance schema, they have all included, now I just add these information for other schemas in production database.