### PR TITLE
Update actions cache

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,6 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
       - name: Build dbt docs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,36 +11,36 @@ env:
   DBT_PROFILES_DIR: transform/ci
   DBT_RAW_DB: RAW_PRD
   DBT_ANALYTICS_DB: ANALYTICS_PRD
-  PRIVATE_KEY: ${{ SECRETS.SNOWFLAKE_PRIVATE_KEY_PRD }}
+  SNOWFLAKE_PRIVATE_KEY: ${{ SECRETS.SNOWFLAKE_PRIVATE_KEY_PRD }}
   SNOWFLAKE_USER: ${{ SECRETS.SNOWFLAKE_USER_PRD }}
   SNOWFLAKE_ACCOUNT: ${{ SECRETS.SNOWFLAKE_ACCOUNT }}
-  SNOWFLAKE_PRIVATE_KEY_PATH: /tmp/private_key.p8
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-        # TODO: once we are on dbt-snowflake 1.5, no need to pipe to a file, we can
-        # just use $SNOWFLAKE_PRIVATE_KEY
-      - name: Set up private key
-        run: echo "$PRIVATE_KEY" > $SNOWFLAKE_PRIVATE_KEY_PATH
-      - uses: actions/cache@v2
-        with:
-          key: ${{ github.ref }}
-          path: .cache
       - uses: snok/install-poetry@v1
         with:
-          virtualenvs-create: false
+          virtualenvs-path: .venv
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
-        run: |
-          poetry install
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
       - name: Build dbt docs
         run: |
-          dbt deps --project-dir=transform
-          dbt docs generate --project-dir=transform --target=prd
-          cp -r transform/target docs/dbt_docs
-      - run: mkdocs gh-deploy --force
+          # Generate snowflake dbt docs
+          poetry run dbt deps --project-dir=transform
+          poetry run dbt docs generate --project-dir=transform
+          cp -r transform/target docs/dbt_docs_snowflake
+      - name: Deploy docs to GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        run: poetry run mkdocs gh-deploy --force

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,33 +6,32 @@ on:
     branches: [main]
 
 env:
-  DBT_PROFILES_DIR: ci
+  DBT_PROFILES_DIR: transform/ci
 
-  PRIVATE_KEY: ${{ SECRETS.SNOWFLAKE_PRIVATE_KEY_DEV }}
+  SNOWFLAKE_PRIVATE_KEY: ${{ SECRETS.SNOWFLAKE_PRIVATE_KEY_DEV }}
   SNOWFLAKE_USER: ${{ SECRETS.SNOWFLAKE_USER_DEV }}
   SNOWFLAKE_ACCOUNT: ${{ SECRETS.SNOWFLAKE_ACCOUNT }}
-  SNOWFLAKE_PRIVATE_KEY_PATH: /tmp/private_key.p8
-
-defaults:
-  run:
-    shell: bash -l {0}
 
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        # TODO: once we are on dbt-snowflake 1.5, no need to pipe to a file, we can
-        # just use $SNOWFLAKE_PRIVATE_KEY
-      - name: Set up private key
-        run: echo "$PRIVATE_KEY" > $SNOWFLAKE_PRIVATE_KEY_PATH
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - uses: snok/install-poetry@v1
         with:
-          virtualenvs-create: false
+          virtualenvs-path: .venv
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
-        run: |
-          poetry install
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+      - name: Install dbt deps
+        run: poetry run dbt deps --project-dir transform
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,7 +30,6 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
       - name: Install dbt deps
         run: poetry run dbt deps --project-dir transform

--- a/.github/workflows/python_jobs.yml
+++ b/.github/workflows/python_jobs.yml
@@ -19,18 +19,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install poetry
-        run: pipx install poetry
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-          cache: "poetry"
-      - uses: actions/cache@v2
+      - uses: snok/install-poetry@v1
         with:
-          key: ${{ github.ref }}
-          path: .cache
+          virtualenvs-path: .venv
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
-        run: poetry install --no-root
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
       - name: Load GIS Datasets
         env:
           SNOWFLAKE_DATABASE: RAW_PRD

--- a/.github/workflows/python_jobs.yml
+++ b/.github/workflows/python_jobs.yml
@@ -32,7 +32,6 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
       - name: Load GIS Datasets
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,25 +39,10 @@ repos:
         args: [--warn-unused-configs]
         additional_dependencies:
           - types-requests
-  - repo: local
-    hooks:
-      - name: Dbt deps
-        id: dbt-deps
-        language: system
-        entry: poetry run dbt deps --project-dir transform
-        always_run: false
-        pass_filenames: false
-        types: [sql]
-  # Note: for SQLFluff we don't use the default pre-commit hook for a few reasons:
-  #   1. dbt cloud looks for config in the dbt project directory, so we put it in
-  #      transform/, however sqlfluff requires the templater config to be in the
-  #      current working directory. So we have to cd to transform/ to properly set the
-  #      templater config.
-  #   2. Some machines (such as ODI Macs) seem to struggle with sqlfluff's
-  #      multiprocessing implementation, so we force it to be single-process.
-  #   3. The pre-commit managed python environment can be difficult to install,
-  #      especially due to issues with pyarrow being brought in by Snowflake.
-  #      This keep things more predictable by using the poetry.lock environment.
+  # Note: for SQLFluff we don't use the default pre-commit hook because
+  # the pre-commit managed python environment can be difficult to install,
+  # especially due to issues with pyarrow being brought in by Snowflake.
+  # This keep things more predictable by using the poetry.lock environment.
   - repo: local
     hooks:
       - id: sqlfluff
@@ -66,8 +51,5 @@ repos:
         description: "Lints sql files with `SQLFluff`"
         types: [sql]
         require_serial: true
-        entry: >
-          poetry run python -c "import os, subprocess; os.chdir('transform');
-          subprocess.run(['sqlfluff', 'fix', '--force', '--processes', '1',
-          '--nocolor', '--show-lint-violations', '--disable-progress-bar'],
-          check=True, )"
+        entry: poetry run sqlfluff fix --show-lint-violations --processes 0 --nocolor --disable-progress-bar
+        pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,5 +51,5 @@ repos:
         description: "Lints sql files with `SQLFluff`"
         types: [sql]
         require_serial: true
-        entry: poetry run sqlfluff fix transform --show-lint-violations --processes 0 --nocolor --disable-progress-bar
+        entry: poetry run sqlfluff fix transform --show-lint-violations --nocolor --disable-progress-bar
         pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,5 +51,5 @@ repos:
         description: "Lints sql files with `SQLFluff`"
         types: [sql]
         require_serial: true
-        entry: poetry run sqlfluff fix --show-lint-violations --processes 0 --nocolor --disable-progress-bar
+        entry: poetry run sqlfluff fix transform --show-lint-violations --processes 0 --nocolor --disable-progress-bar
         pass_filenames: true

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,9 @@
+[sqlfluff]
+# For some reason this can only be set in the root directory, cf
+# https://docs.sqlfluff.com/en/stable/configuration.html#nesting.
+# Other config parameters are set in the dbt project directory, as
+# that's where dbt cloud looks for them.
+templater = dbt
+
+[sqlfluff:templater:dbt]
+project_dir = ./transform

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -4,6 +4,7 @@
 # Other config parameters are set in the dbt project directory, as
 # that's where dbt cloud looks for them.
 templater = dbt
+dialect = snowflake
 
 [sqlfluff:templater:dbt]
 project_dir = ./transform

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,6 +1,6 @@
 [sqlfluff]
 # For some reason this can only be set in the root directory, cf
-# https://docs.sqlfluff.com/en/stable/configuration.html#nesting.
+# https://docs.sqlfluff.com/en/stable/configuration/setting_configuration.html#nesting
 # Other config parameters are set in the dbt project directory, as
 # that's where dbt cloud looks for them.
 templater = dbt

--- a/transform/ci/profiles.yml
+++ b/transform/ci/profiles.yml
@@ -6,7 +6,7 @@ caltrans_pems:
 
       account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
       user: "{{ env_var('SNOWFLAKE_USER') }}"
-      private_key_path: "{{ env_var('SNOWFLAKE_PRIVATE_KEY_PATH') }}"
+      private_key: "{{ env_var('SNOWFLAKE_PRIVATE_KEY') }}"
       role: READER_DEV
       warehouse: REPORTING_XS_DEV
       database: ANALYTICS_DEV
@@ -17,7 +17,7 @@ caltrans_pems:
 
       account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
       user: "{{ env_var('SNOWFLAKE_USER') }}"
-      private_key_path: "{{ env_var('SNOWFLAKE_PRIVATE_KEY_PATH') }}"
+      private_key: "{{ env_var('SNOWFLAKE_PRIVATE_KEY') }}"
       role: READER_PRD
       warehouse: REPORTING_XS_PRD
       database: ANALYTICS_PRD


### PR DESCRIPTION
Part of fixing https://github.com/cagov/caldata-dse-internal-tracker/issues/68

Updates `@actions/cache` so that we no longer run the deprecated version, and generally fixes it so it works properly