### PR TITLE
Use correct target for docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,6 @@
 name: docs
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -38,7 +39,7 @@ jobs:
         run: |
           # Generate snowflake dbt docs
           poetry run dbt deps --project-dir=transform
-          poetry run dbt docs generate --project-dir=transform
+          poetry run dbt docs generate --project-dir=transform --target=prd
           cp -r transform/target docs/dbt_docs_snowflake
       - name: Deploy docs to GitHub Pages
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Fixes #556, this was an oversight in my recent github actions refresh. We build the docs using the "prd" target so that the docs render with the production schema/database names.