### PR TITLE
Fix nightly build

### DIFF
--- a/transform/models/marts/imputation/imputation__detector_summary.sql
+++ b/transform/models/marts/imputation/imputation__detector_summary.sql
@@ -1,7 +1,8 @@
 {{ config(
     materialized="incremental",
     unique_key=['detector_id', 'sample_date'],
-    snowflake_warehouse=get_snowflake_refresh_warehouse(big="XL")
+    snowflake_warehouse=get_snowflake_refresh_warehouse(big="XL"),
+    unload_partitioning="('year=' || to_varchar(date_part(year, sample_date)) || '/month=' || to_varchar(date_part(month, sample_date)))",
 ) }}
 
 -- read observed and imputed five minutes data


### PR DESCRIPTION
1. Explicitly cast a date. At this point it's unclear what was suddenly causing failures in this model, as `sample_date` is already a date, as far as I can tell. I suspect some bug deep in Snowflake...
1. Filter earlier in global coefficients model -- the Snowflake optimizer was having a difficult time doing filter pushdowns, and was scanning way to much of the underlying five-minute table for an incremental model