### PR TITLE
disable freshness tests

### DIFF
--- a/transform/models/_sources.yml
+++ b/transform/models/_sources.yml
@@ -282,7 +282,6 @@ sources:
           for an onramp.
         data_tests:
           - not_empty
-          - copy_history_24h
           - unique:
               column_name: controller_id
         columns:
@@ -312,7 +311,6 @@ sources:
               combination_of_columns:
                 - controller_id
                 - time_id
-          - copy_history_24h
         freshness:
           warn_after:
             count: 30
@@ -353,7 +351,6 @@ sources:
           Metadata for a single VDS station. Multiple stations may be connected to
           a single controller, and multiple detectors may be connected to a single station.
         data_tests:
-          - copy_history_24h
           - not_empty
           - unique:
               column_name: station_id
@@ -379,7 +376,6 @@ sources:
           A log table showing updates to the station config. This can be joined
           with the `station_config` table to get a full history of station metadata.
         data_tests:
-          - copy_history_24h
           - not_empty
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns:
@@ -432,7 +428,6 @@ sources:
           Multiple detectors across a set of lanes constitute a station.
         data_tests:
           - not_empty
-          - copy_history_24h
           - unique:
               column_name: detector_id
         columns:
@@ -448,7 +443,6 @@ sources:
           with the `detector_config` table to get a full history of detector metadata.
         data_tests:
           - not_empty
-          - copy_history_24h
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns:
                 - detector_id


### PR DESCRIPTION
These tests have seemingly started failing because the uploader script within caltrans has stopped. Nobody is maintaining that, so we can't really address it on this side.

If/when this project gets un-paused, we can revisit