### PR TITLE
fix errant test deletion.

### DIFF
--- a/transform/models/marts/imputation/_imputation.yml
+++ b/transform/models/marts/imputation/_imputation.yml
@@ -74,6 +74,11 @@ models:
       This model filters the results of the imputation_detector_imputed_agg_five_minutes model from the transform
       step to detectors with station_type in of either 'ML' or 'HV' from the past 4 days and adds the county name
       to the results. This model is unique at the level of SAMPLE_TIMESTAMP + DETECTOR_ID.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - SAMPLE_DATE
+            - DETECTOR_ID
     columns:
       - name: DETECTOR_ID
         data_tests:


### PR DESCRIPTION
missed a comment on a deleted test due to message stacking
 undelete
 
    data_tests:
      - dbt_utils.unique_combination_of_columns:
          combination_of_columns:
            - SAMPLE_DATE
            - DETECTOR_ID
            on the imputation__detector_imputed_agg_five_minutes model